### PR TITLE
Fix e2e tests.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 ARG REPO_BUILD_TAG="unknown"
 
-FROM golang:1.20-alpine AS builder
+# Pin alpine 3.18. 
+# See https://github.com/mattn/go-sqlite3/issues/1164#issuecomment-1848677118
+FROM golang:1.20-alpine3.18 AS builder
 ARG REPO_BUILD_TAG
 COPY . /build
 WORKDIR /build

--- a/cmd/backup_delete.go
+++ b/cmd/backup_delete.go
@@ -114,12 +114,6 @@ func doDeleteBackupFlagValidation(flags *pflag.FlagSet) {
 			execOSExit(exitErrorCode)
 		}
 	}
-	// history-file flag and history-db flags cannot be used together for backup-delete command.
-	err = checkCompatibleFlags(flags, rootHistoryDBFlagName, rootHistoryFilesFlagName)
-	if err != nil {
-		gplog.Error(textmsg.ErrorTextUnableCompatibleFlags(err, rootHistoryDBFlagName, rootHistoryFilesFlagName))
-		execOSExit(exitErrorCode)
-	}
 }
 
 func doDeleteBackup() {
@@ -377,12 +371,12 @@ func checkBackupCanBeDeleted(backupData gpbckpconfig.BackupConfig) bool {
 	result := false
 	backupSuccessStatus, err := backupData.IsSuccess()
 	if err != nil {
-		gplog.Error(textmsg.ErrorTextUnableGetBackupInfo(backupData.Timestamp, err))
+		gplog.Error(textmsg.ErrorTextUnableGetBackupValue("status", backupData.Timestamp, err))
 		// There is no point in performing further checks.
 		return result
 	}
 	if !backupSuccessStatus {
-		gplog.Warn(textmsg.WarnTextBackupUnableDeleteFailed(backupData.Timestamp))
+		gplog.Warn(textmsg.WarnTextBackupFailedStatus(backupData.Timestamp))
 		return result
 	}
 	// Checks, if this is local backup.

--- a/e2e_tests/.env
+++ b/e2e_tests/.env
@@ -1,7 +1,9 @@
 IMAGE_GPBACKMAN=gpbackman
 IMAGE_TAG_MINIO=RELEASE.2023-09-07T02-05-02Z
 IMAGE_TAG_MINIO_MC=RELEASE.2023-09-07T22-48-55Z
-S3_PLUGIN_VERSION=1.10.1
+# Don't upgade s3 plugin version until https://github.com/greenplum-db/gpbackup-s3-plugin/issues/61
+# will be fixed.
+S3_PLUGIN_VERSION=1.10.0
 MINIO_ROOT_USER=minio
 MINIO_ROOT_PASSWORD=minioBackup
 MINIO_SITE_REGION=us-west-1

--- a/e2e_tests/conf/gpbackup_s3_plugin.yaml
+++ b/e2e_tests/conf/gpbackup_s3_plugin.yaml
@@ -8,4 +8,3 @@ options:
   bucket: backup
   folder: test
   encryption: off
-

--- a/textmsg/warn.go
+++ b/textmsg/warn.go
@@ -6,6 +6,6 @@ func WarnTextBackupAlreadyDeleted(backupName string) string {
 	return fmt.Sprintf("Backup %s has already been deleted", backupName)
 }
 
-func WarnTextBackupUnableDeleteFailed(backupName string) string {
-	return fmt.Sprintf("Backup %s has failed status. Nothing to delete", backupName)
+func WarnTextBackupFailedStatus(backupName string) string {
+	return fmt.Sprintf("Backup %s has failed status. Nothing to do", backupName)
 }

--- a/textmsg/warn_test.go
+++ b/textmsg/warn_test.go
@@ -20,8 +20,8 @@ func TestWarnTextFunctionsWarnAndArg(t *testing.T) {
 		{
 			name:     "Test WarnTextBackupUnableDeleteFailed",
 			value:    "TestBackup",
-			function: WarnTextBackupUnableDeleteFailed,
-			want:     "Backup TestBackup has failed status. Nothing to delete",
+			function: WarnTextBackupFailedStatus,
+			want:     "Backup TestBackup has failed status. Nothing to do",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
* Rollback to `1.10.0` version of the gpbackup-s3-plugin. There is a bug in version `1.10.1 https://github.com/greenplum-db/gpbackup-s3-plugin/issues/61.
* Pin the alpine `3.18` golang image for the builder. See https://github.com/mattn/go-sqlite3/issues/1164#issuecomment-1848677118 for more details.
* Remove duplicate code for the `backup-delete` command. Rename the function for the warning message about failed backups.