### PR TITLE
Add report-info command.

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -1,0 +1,373 @@
+- [Delete existing backup (`backup-delete`)](#delete-existing-backup-backup-delete)
+  - [Examples](#examples)
+    - [Delete existing backup from local storage](#delete-existing-backup-from-local-storage)
+    - [Delete existing backup using storage plugin](#delete-existing-backup-using-storage-plugin)
+  - [Using container](#using-container)
+- [Display information about backups (`backup-info`)](#display-information-about-backups-backup-info)
+  - [Examples](#examples-1)
+  - [Using container](#using-container-1)
+- [Migrate history database (`history-migrate`)](#migrate-history-database-history-migrate)
+  - [Examples](#examples-2)
+  - [Using container](#using-container-2)
+- [Display the backup report (`report-info`)](#display-the-backup-report-report-info)
+  - [Examples](#examples-3)
+    - [Display the backup report from local storage](#display-the-backup-report-from-local-storage)
+    - [Display the backup report using storage plugin](#display-the-backup-report-using-storage-plugin)
+  - [Using container](#using-container-3)
+
+
+# Delete existing backup (`backup-delete`)
+
+Available options for `backup-delete` command and their description:
+
+```bash
+./gpbackman backup-delete -h
+Delete a specific backup set.
+
+The --timestamp option must be specified. It could be specified multiple times.
+
+By default, the existence of dependent backups is checked and deletion process is not performed,
+unless the --cascade option is passed in.
+
+If backup already deleted, the deletion process is skipped, unless --force option is specified.
+
+By default, he deletion will be performed for local backup (in development).
+
+The storage plugin config file location can be set using the --plugin-config option.
+The full path to the file is required. In this case, the deletion will be performed using the storage plugin.
+
+The gpbackup_history.db file location can be set using the --history-db option.
+Can be specified only once. The full path to the file is required.
+
+The gpbackup_history.yaml file location can be set using the --history-file option.
+Can be specified multiple times. The full path to the file is required.
+
+If no --history-file or --history-db options are specified, the history database will be searched in the current directory.
+
+Only --history-file or --history-db option can be specified, not both.
+
+Usage:
+  gpbackman backup-delete [flags]
+
+Flags:
+      --cascade                 delete all dependent backups for the specified backup timestamp
+      --force                   try to delete, even if the backup already mark as deleted
+  -h, --help                    help for backup-delete
+      --plugin-config string    the full path to plugin config file
+      --timestamp stringArray   the backup timestamp for deleting, could be specified multiple times
+
+Global Flags:
+      --history-db string          full path to the gpbackup_history.db file
+      --history-file stringArray   full path to the gpbackup_history.yaml file, could be specified multiple times
+      --log-file string            full path to log file directory, if not specified, the log file will be created in the $HOME/gpAdminLogs directory
+      --log-level-console string   level for console logging (error, info, debug, verbose) (default "info")
+      --log-level-file string      level for file logging (error, info, debug, verbose) (default "info")
+```
+
+## Examples
+### Delete existing backup from local storage
+
+The functionality is in development.
+
+gpBackMan returns a message:
+```bash
+[WARNING]:-The functionality is still in development
+```
+### Delete existing backup using storage plugin
+Delete specific backup:
+```bash
+./gpbackman backup-delete \
+  --timestamp 20230725101959 \
+  --plugin-config /tmp/gpbackup_plugin_config.yaml
+```
+
+Delete specific backup and all dependent backups:
+```bash
+./gpbackman backup-delete\
+  --timestamp 20230725101115 \
+  --plugin-config /tmp/gpbackup_plugin_config.yaml \
+  --cascade
+```
+
+## Using container
+
+Delete the backup using `gpbackup_s3_plugin` storage plugin:
+```bash
+docker run \
+  --name gpbackman \
+  -e GPBACKMAN_UID=$(id -u) \
+  -e GPBACKMAN_GID=$(id -g) \
+  -v /data/master/gpseg-1/gpbackup_history.db:/data/master/gpseg-1/gpbackup_history.db \
+  -v /path/to/gpbackup_s3_plugin:/tmp/gpbackup_s3_plugin \
+  -v /path/to/gpbackup_plugin_config.yaml:/tmp/gpbackup_plugin_config.yaml \
+  gpbackman \
+  gpbackman backup-delete \
+  --timestamp 20230725101959 \
+  --history-db /data/master/gpseg-1/gpbackup_history.db \
+  --plugin-config /tmp/gpbackup_plugin_config.yaml
+```
+
+
+
+# Display information about backups (`backup-info`)
+
+Available options for `backup-info` command and their description:
+
+```bash
+./gpbackman backup-info -h
+Display a list of backups.
+
+By default, only active backups or backups with deletion status "In progress" from gpbackup_history.db are displayed.
+
+To additional display deleted backups, use the --show-deleted option.
+To additional display failed backups, use the --show-failed option.
+To display all backups, use --show-deleted  and --show-failed options together.
+
+The gpbackup_history.db file location can be set using the --history-db option.
+Can be specified only once. The full path to the file is required.
+
+The gpbackup_history.yaml file location can be set using the --history-file option.
+Can be specified multiple times. The full path to the file is required.
+
+If no --history-file or --history-db options are specified, the history database will be searched in the current directory.
+
+Only --history-file or --history-db option can be specified, not both.
+
+Usage:
+  gpbackman backup-info [flags]
+
+Flags:
+  -h, --help           help for backup-info
+      --show-deleted   show deleted backups
+      --show-failed    show failed backups
+
+Global Flags:
+      --history-db string          full path to the gpbackup_history.db file
+      --history-file stringArray   full path to the gpbackup_history.yaml file, could be specified multiple times
+      --log-file string            full path to log file directory, if not specified, the log file will be created in the $HOME/gpAdminLogs directory
+      --log-level-console string   level for console logging (error, info, debug, verbose) (default "info")
+      --log-level-file string      level for file logging (error, info, debug, verbose) (default "info")
+```
+
+The following information is provided about each backup:
+* `TIMESTAMP` - backup name, timestamp (`YYYYMMDDHHMMSS`) when the backup was taken;
+* `DATE`- date in format `Mon Jan 02 2006 15:04:05` when the backup was taken;
+* `STATUS`- backup status: `Success` or `Failure`; 
+* `DATABASE` - database name for which the backup was performed	(specified by `--dbname` option on the `gpbackup` command).
+* `TYPE` - backup type:
+    - `full` - contains user data, all global and local metadata for the database;
+    - `incremental` – contains user data, all global and local metadata changed since a previous full backup;
+    - `metadata-only` – contains only global and local metadata for the database;
+    - `data-only` – contains only user data from the database.
+
+* `OBJECT FILTERING` - whether the object filtering options were used when executing the `gpbackup` command:
+    - `include-schema` – at least one `--include-schema` option was specified;
+    - `exclude-schema` – at least one `--exclude-schema` option was specified;
+    - `include-table` – at least one `--include-table` option was specified;
+    - `exclude-table` – at least one `--exclude-table` option was specified;
+    - `""` - no options was specified.
+
+* `PLUGIN` - plugin name that was used to configure the backup destination;
+* `DURATION` -  backup duration in the format `hh:mm:ss`;
+* `DATE DELETED` - backup deletion status:
+    - `In progress` - the deletion is in progress;
+    - `Plugin Backup Delete Failed` - last delete attempt failed to delete backup from plugin storage;
+    - `Local Delete Failed` - last delete attempt failed to delete backup from local storage.;
+    - `""` - if backup is active;
+    - date  in format `Mon Jan 02 2006 15:04:05` - if backup is deleted and deletion timestamp is set.
+
+If gpbackup is launched without specifying `--metadata-only` flag, but there were no tables that contain data for backup, then gpbackup will only perform a `metadata-only` backup. The logs will contain messages like `No tables in backup set contain data. Performing metadata-only backup instead.` As a result, gpBackMan will display such backups as `metadata-only`.
+
+## Examples
+
+Display info for active backups from `gpbackup_history.db`:
+```bash
+./gpbackman backup-info
+
+ TIMESTAMP      | DATE                     | STATUS  | DATABASE | TYPE          | OBJECT FILTERING | PLUGIN             | DURATION | DATE DELETED 
+----------------+--------------------------+---------+----------+---------------+------------------+--------------------+----------+--------------
+ 20230725101959 | Tue Jul 25 2023 10:19:59 | Success | demo     | incremental   |                  | gpbackup_s3_plugin | 00:00:22 |              
+ 20230725101152 | Tue Jul 25 2023 10:11:52 | Success | demo     | incremental   |                  | gpbackup_s3_plugin | 00:00:18 |              
+ 20230725101115 | Tue Jul 25 2023 10:11:15 | Success | demo     | full          |                  | gpbackup_s3_plugin | 00:00:20 |              
+ 20230724090000 | Mon Jul 24 2023 09:00:00 | Success | demo     | metadata-only |                  | gpbackup_s3_plugin | 00:25:17 |              
+ 20230723082000 | Sun Jul 23 2023 08:20:00 | Success | demo     | data-only     |                  | gpbackup_s3_plugin | 00:05:17 |              
+```
+
+Display info for all backups from `gpbackup_history.yaml`:
+```bash
+./gpbackman backup-info \
+  --show-deleted \
+  --show-failed \
+  --history-file /data/master/gpseg-1/gpbackup_history.yaml
+
+ TIMESTAMP      | DATE                     | STATUS  | DATABASE | TYPE          | OBJECT FILTERING | PLUGIN             | DURATION | DATE DELETED             
+----------------+--------------------------+---------+----------+---------------+------------------+--------------------+----------+--------------------------
+ 20230809232817 | Wed Aug 09 2023 23:28:17 | Success | demo     | full          |                  |                    | 04:00:03 |                          
+ 20230806230400 | Sun Aug 06 2023 23:04:00 | Failure | demo     | full          |                  | gpbackup_s3_plugin | 00:00:38 |                          
+ 20230725110310 | Tue Jul 25 2023 11:03:10 | Success | demo     | incremental   |                  | gpbackup_s3_plugin | 00:00:18 | Wed Jul 26 2023 11:03:28 
+ 20230725101959 | Tue Jul 25 2023 10:19:59 | Success | demo     | incremental   |                  | gpbackup_s3_plugin | 00:00:22 |                          
+ 20230725101152 | Tue Jul 25 2023 10:11:52 | Success | demo     | incremental   |                  | gpbackup_s3_plugin | 00:00:18 |                          
+ 20230725101115 | Tue Jul 25 2023 10:11:15 | Success | demo     | full          |                  | gpbackup_s3_plugin | 00:00:20 |                          
+ 20230724090000 | Mon Jul 24 2023 09:00:00 | Success | demo     | metadata-only |                  | gpbackup_s3_plugin | 00:25:17 |                          
+ 20230723082000 | Sun Jul 23 2023 08:20:00 | Success | demo     | data-only     |                  | gpbackup_s3_plugin | 00:05:17 |                          
+```
+
+## Using container
+
+```bash
+docker run \
+  --name gpbackman \
+  -v /data/master/gpseg-1/gpbackup_history.db:/data/master/gpseg-1/gpbackup_history.db \
+  gpbackman \
+  gpbackman backup-info \
+  --history-db /data/master/gpseg-1/gpbackup_history.db
+```
+
+# Migrate history database (`history-migrate`)
+
+Available options for `history-migrate` command and their description:
+
+```bash
+./gpbackman history-migrate -h
+Migrate data from gpbackup_history.yaml to gpbackup_history.db SQLite history database.
+
+The data from the gpbackup_history.yaml file will be uploaded to gpbackup_history.db SQLite history database.
+If the gpbackup_history.db file does not exist, it will be created.
+The gpbackup_history.yaml file will be renamed to gpbackup_history.yaml.migrated.
+
+The gpbackup_history.db file location can be set using the  --history-db option.
+Can be specified only once. The full path to the file is required.
+
+The gpbackup_history.yaml file location can be set using the  --history-file option.
+Can be specified multiple times. The full path to the file is required.
+
+If no --history-file and/or --history-db options are specified, the files will be searched in the current directory.
+
+Usage:
+  gpbackman history-migrate [flags]
+
+Flags:
+  -h, --help   help for history-migrate
+
+Global Flags:
+      --history-db string          full path to the gpbackup_history.db file
+      --history-file stringArray   full path to the gpbackup_history.yaml file, could be specified multiple times
+      --log-file string            full path to log file directory, if not specified, the log file will be created in the $HOME/gpAdminLogs directory
+      --log-level-console string   level for console logging (error, info, debug, verbose) (default "info")
+      --log-level-file string      level for file logging (error, info, debug, verbose) (default "info")
+```
+
+## Examples
+
+Migrate data from several gpbackup_history.yaml files to gpbackup_history.db SQLite history database:
+```bash
+./gpbackman history-migrate \
+  --history-file /data/master/gpseg-1/gpbackup_history.yaml \
+  --history-file /tmp/gpbackup_history.yaml \
+  --history-db /data/master/gpseg-1/gpbackup_history.db
+```
+
+## Using container
+
+```bash
+docker run \
+  --name gpbackman \
+  -e GPBACKMAN_UID=$(id -u) \
+  -e GPBACKMAN_GID=$(id -g) \
+  -v /data/master/gpseg-1/:/data/master/gpseg-1/ \
+  gpbackman \
+  gpbackman history-migrate \
+  --history-file /data/master/gpseg-1/gpbackup_history.yaml \
+  --history-db /data/master/gpseg-1/gpbackup_history.db
+```
+
+# Display the backup report (`report-info`)
+
+Available options for `report-info` command and their description:
+
+```bash
+./gpbackman.go report-info -h
+Display the report for specific backup set.
+
+The --timestamp option must be specified.
+
+The report could be displayed only for active backups.
+
+The storage plugin config file location can be set using the --plugin-config option.
+The full path to the file is required.
+
+If a custom plugin is used, it is required to specify the path to the directory with the repo file using the --plugin-report-file-path option.
+It is not necessary to use the --plugin-report-file-path flag for the following plugins (the path is generated automatically):
+  * gpbackup_s3_plugin,
+
+The gpbackup_history.db file location can be set using the --history-db option.
+Can be specified only once. The full path to the file is required.
+
+The gpbackup_history.yaml file location can be set using the --history-file option.
+Can be specified multiple times. The full path to the file is required.
+
+If no --history-file or --history-db options are specified, the history database will be searched in the current directory.
+
+Only --history-file or --history-db option can be specified, not both.
+
+Usage:
+  gpbackman report-info [flags]
+
+Flags:
+  -h, --help                             help for report-info
+      --plugin-config string             the full path to plugin config file
+      --plugin-report-file-path string   the full path to plugin report file
+      --timestamp string                 the backup timestamp for report displaying
+
+Global Flags:
+      --history-db string          full path to the gpbackup_history.db file
+      --history-file stringArray   full path to the gpbackup_history.yaml file, could be specified multiple times
+      --log-file string            full path to log file directory, if not specified, the log file will be created in the $HOME/gpAdminLogs directory
+      --log-level-console string   level for console logging (error, info, debug, verbose) (default "info")
+      --log-level-file string      level for file logging (error, info, debug, verbose) (default "info")
+```
+
+## Examples
+### Display the backup report from local storage
+
+The functionality is in development.
+
+gpBackMan returns a message:
+```bash
+[WARNING]:-The functionality is still in development
+```
+
+### Display the backup report using storage plugin
+
+For `gpbackup_s3_plugin`:
+```bash
+./gpbackman report-info \
+  --timestamp 20230725101959 \
+  --plugin-config /tmp/gpbackup_plugin_config.yaml
+```
+
+For other plugins:
+```bash
+./gpbackman report-infodoc \
+  --timestamp 20230725101959 \
+  --plugin-config /tmp/gpbackup_plugin_config.yaml \
+  --plugin-report-file-path /some/path/to/report
+```
+
+## Using container
+
+Display the backup report using `gpbackup_s3_plugin` storage plugin:
+```bash
+docker run \
+  --name gpbackman \
+  -e GPBACKMAN_UID=$(id -u) \
+  -e GPBACKMAN_GID=$(id -g) \
+  -v /data/master/gpseg-1/gpbackup_history.db:/data/master/gpseg-1/gpbackup_history.db \
+  -v /path/to/gpbackup_s3_plugin:/tmp/gpbackup_s3_plugin \
+  -v /path/to/gpbackup_plugin_config.yaml:/tmp/gpbackup_plugin_config.yaml \
+  gpbackman \
+  gpbackman report-info \
+  --timestamp 20230725101959 \
+  --history-db /data/master/gpseg-1/gpbackup_history.db \
+  --plugin-config /tmp/gpbackup_plugin_config.yaml
+```

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -189,9 +189,9 @@ Display info for active backups from `gpbackup_history.db`:
  20230725101959 | Tue Jul 25 2023 10:19:59 | Success | demo     | incremental   |                  | gpbackup_s3_plugin | 00:00:22 |              
  20230725101152 | Tue Jul 25 2023 10:11:52 | Success | demo     | incremental   |                  | gpbackup_s3_plugin | 00:00:18 |              
  20230725101115 | Tue Jul 25 2023 10:11:15 | Success | demo     | full          |                  | gpbackup_s3_plugin | 00:00:20 |              
- 20230724090000 | Mon Jul 24 2023 09:00:00 | Success | demo     | metadata-only |                  | gpbackup_s3_plugin | 00:25:17 |              
- 20230723082000 | Sun Jul 23 2023 08:20:00 | Success | demo     | data-only     |                  | gpbackup_s3_plugin | 00:05:17 |              
-```
+ 20230724090000 | Mon Jul 24 2023 09:00:00 | Success | demo     | metadata-only |                  | gpbackup_s3_plugin | 00:05:17 |              
+ 20230723082000 | Sun Jul 23 2023 08:20:00 | Success | demo     | data-only     |                  | gpbackup_s3_plugin | 00:35:17 |              
+ ```
 
 Display info for all backups from `gpbackup_history.yaml`:
 ```bash
@@ -199,18 +199,17 @@ Display info for all backups from `gpbackup_history.yaml`:
   --show-deleted \
   --show-failed \
   --history-file /data/master/gpseg-1/gpbackup_history.yaml
-
- TIMESTAMP      | DATE                     | STATUS  | DATABASE | TYPE          | OBJECT FILTERING | PLUGIN             | DURATION | DATE DELETED             
-----------------+--------------------------+---------+----------+---------------+------------------+--------------------+----------+--------------------------
- 20230809232817 | Wed Aug 09 2023 23:28:17 | Success | demo     | full          |                  |                    | 04:00:03 |                          
- 20230806230400 | Sun Aug 06 2023 23:04:00 | Failure | demo     | full          |                  | gpbackup_s3_plugin | 00:00:38 |                          
+ TIMESTAMP      | DATE                     | STATUS  | DATABASE | TYPE          | OBJECT FILTERING | PLUGIN             | DURATION | DATE DELETED 
+----------------+--------------------------+---------+----------+---------------+------------------+--------------------+----------+--------------
+ 20230809232817 | Wed Aug 09 2023 23:28:17 | Success | demo     | full          |                  |                    | 04:00:03 |              
+ 20230725102831 | Tue Jul 25 2023 10:28:31 | Success | demo     | incremental   |                  | gpbackup_s3_plugin | 00:00:18 |              
  20230725110310 | Tue Jul 25 2023 11:03:10 | Success | demo     | incremental   |                  | gpbackup_s3_plugin | 00:00:18 | Wed Jul 26 2023 11:03:28 
  20230725101959 | Tue Jul 25 2023 10:19:59 | Success | demo     | incremental   |                  | gpbackup_s3_plugin | 00:00:22 |                          
  20230725101152 | Tue Jul 25 2023 10:11:52 | Success | demo     | incremental   |                  | gpbackup_s3_plugin | 00:00:18 |                          
  20230725101115 | Tue Jul 25 2023 10:11:15 | Success | demo     | full          |                  | gpbackup_s3_plugin | 00:00:20 |                          
- 20230724090000 | Mon Jul 24 2023 09:00:00 | Success | demo     | metadata-only |                  | gpbackup_s3_plugin | 00:25:17 |                          
- 20230723082000 | Sun Jul 23 2023 08:20:00 | Success | demo     | data-only     |                  | gpbackup_s3_plugin | 00:05:17 |                          
-```
+ 20230724090000 | Mon Jul 24 2023 09:00:00 | Success | demo     | metadata-only |                  | gpbackup_s3_plugin | 00:05:17 |                          
+ 20230723082000 | Sun Jul 23 2023 08:20:00 | Success | demo     | data-only     |                  | gpbackup_s3_plugin | 00:35:17 |                          
+ ```
 
 ## Using container
 

--- a/Makefile
+++ b/Makefile
@@ -17,11 +17,10 @@ test:
 test-e2e:
 	@echo "Run end-to-end tests for $(APP_NAME)"
 	@make docker
-	$(call down_docker_compose)
-	$(call run_docker_compose,backup-info)
-	$(call run_docker_compose,backup-delete)
-	$(call run_docker_compose,history-migrate)
-	$(call down_docker_compose)
+	@make test-e2e_backup-info
+	@make test-e2e_report-info
+	@make test-e2e_backup-delete
+	@make test-e2e_history-migrate
 
 .PHONY: test-e2e_backup-info
 test-e2e_backup-info:
@@ -42,6 +41,13 @@ test-e2e_history-migrate:
 	@echo "Run end-to-end tests for $(APP_NAME) for history-migrate command"
 	$(call down_docker_compose)
 	$(call run_docker_compose,history-migrate)
+	$(call down_docker_compose)
+
+.PHONY: test-e2e_report-info
+test-e2e_report-info:
+	@echo "Run end-to-end tests for $(APP_NAME) for report-info command"
+	$(call down_docker_compose)
+	$(call run_docker_compose,report-info)
 	$(call down_docker_compose)
 
 .PHONY: test-e2e-down

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@
 The utility works with both history database formats: `gpbackup_history.yaml` file format (before gpbackup `1.29.0`) and  `gpbackup_history.db` SQLite format (starting from gpbackup `1.29.0`).
 
 **gpBackMan** provides the following features:
-* display information about backups.
+* display information about backups;
+* display the backup report for existing backups;
 * delete existing backups from local storage or using storage plugins (for example, [S3 Storage Plugin](https://github.com/greenplum-db/gpbackup-s3-plugin));
 * migrate history database from `gpbackup_history.yaml` format to `gpbackup_history.db` SQLite format.
 
@@ -32,6 +33,7 @@ Available Commands:
   completion      Generate the autocompletion script for the specified shell
   help            Help about any command
   history-migrate Migrate data from gpbackup_history.yaml to gpbackup_history.db SQLite history database
+  report-info     Display the report for specific backup set
 
 Flags:
   -h, --help                       help for gpbackman
@@ -45,222 +47,13 @@ Flags:
 Use "gpbackman [command] --help" for more information about a command.
 ```
 
-### Display information about backups (`backup-info`)
+### Detail info about commands
 
-Available options for `backup-info` command and their description:
-
-```bash
-./gpbackman backup-info -h
-Display a list of backups.
-
-By default, only active backups or backups with deletion status "In progress" from gpbackup_history.db are displayed.
-
-To additional display deleted backups, use the --show-deleted option.
-To additional display failed backups, use the --show-failed option.
-To display all backups, use --show-deleted  and --show-failed options together.
-
-The gpbackup_history.db file location can be set using the --history-db option.
-Can be specified only once. The full path to the file is required.
-
-The gpbackup_history.yaml file location can be set using the --history-file option.
-Can be specified multiple times. The full path to the file is required.
-
-If no --history-file or --history-db options are specified, the history database will be searched in the current directory.
-
-Only --history-file or --history-db option can be specified, not both.
-
-Usage:
-  gpbackman backup-info [flags]
-
-Flags:
-  -h, --help           help for backup-info
-      --show-deleted   show deleted backups
-      --show-failed    show failed backups
-
-Global Flags:
-      --history-db string          full path to the gpbackup_history.db file
-      --history-file stringArray   full path to the gpbackup_history.yaml file, could be specified multiple times
-      --log-file string            full path to log file directory, if not specified, the log file will be created in the $HOME/gpAdminLogs directory
-      --log-level-console string   level for console logging (error, info, debug, verbose) (default "info")
-      --log-level-file string      level for file logging (error, info, debug, verbose) (default "info")
-```
-
-The following information is provided about each backup:
-* `TIMESTAMP` - backup name, timestamp (`YYYYMMDDHHMMSS`) when the backup was taken;
-* `DATE`- date in format `Mon Jan 02 2006 15:04:05` when the backup was taken;
-* `STATUS`- backup status: `Success` or `Failure`; 
-* `DATABASE` - database name for which the backup was performed	(specified by `--dbname` option on the `gpbackup` command).
-* `TYPE` - backup type:
-    - `full` - contains user data, all global and local metadata for the database;
-    - `incremental` – contains user data, all global and local metadata changed since a previous full backup;
-    - `metadata-only` – contains only global and local metadata for the database;
-    - `data-only` – contains only user data from the database.
-
-* `OBJECT FILTERING` - whether the object filtering options were used when executing the `gpbackup` command:
-    - `include-schema` – at least one `--include-schema` option was specified;
-    - `exclude-schema` – at least one `--exclude-schema` option was specified;
-    - `include-table` – at least one `--include-table` option was specified;
-    - `exclude-table` – at least one `--exclude-table` option was specified;
-    - `""` - no options was specified.
-
-* `PLUGIN` - plugin name that was used to configure the backup destination;
-* `DURATION` -  backup duration in the format `hh:mm:ss`;
-* `DATE DELETED` - backup deletion status:
-    - `In progress` - the deletion is in progress;
-    - `Plugin Backup Delete Failed` - last delete attempt failed to delete backup from plugin storage;
-    - `Local Delete Failed` - last delete attempt failed to delete backup from local storage.;
-    - `""` - if backup is active;
-    - date  in format `Mon Jan 02 2006 15:04:05` - if backup is deleted and deletion timestamp is set.
-
-If gpbackup is launched without specifying `--metadata-only` flag, but there were no tables that contain data for backup, then gpbackup will only perform a `metadata-only` backup. The logs will contain messages like `No tables in backup set contain data. Performing metadata-only backup instead.` As a result, gpBackMan will display such backups as `metadata-only`.
-
-#### Examples
-Display info for active backups from `gpbackup_history.db`:
-```bash
-./gpbackman backup-info
-
- TIMESTAMP      | DATE                     | STATUS  | DATABASE | TYPE          | OBJECT FILTERING | PLUGIN             | DURATION | DATE DELETED 
-----------------+--------------------------+---------+----------+---------------+------------------+--------------------+----------+--------------
- 20230725101959 | Tue Jul 25 2023 10:19:59 | Success | demo     | incremental   |                  | gpbackup_s3_plugin | 00:00:22 |              
- 20230725101152 | Tue Jul 25 2023 10:11:52 | Success | demo     | incremental   |                  | gpbackup_s3_plugin | 00:00:18 |              
- 20230725101115 | Tue Jul 25 2023 10:11:15 | Success | demo     | full          |                  | gpbackup_s3_plugin | 00:00:20 |              
- 20230724090000 | Mon Jul 24 2023 09:00:00 | Success | demo     | metadata-only |                  | gpbackup_s3_plugin | 00:25:17 |              
- 20230723082000 | Sun Jul 23 2023 08:20:00 | Success | demo     | data-only     |                  | gpbackup_s3_plugin | 00:05:17 |              
-```
-
-Display info for all backups from `gpbackup_history.yaml`:
-```bash
-./gpbackman backup-info \
-  --show-deleted \
-  --show-failed \
-  --history-file /data/master/gpseg-1/gpbackup_history.yaml
-
- TIMESTAMP      | DATE                     | STATUS  | DATABASE | TYPE          | OBJECT FILTERING | PLUGIN             | DURATION | DATE DELETED             
-----------------+--------------------------+---------+----------+---------------+------------------+--------------------+----------+--------------------------
- 20230809232817 | Wed Aug 09 2023 23:28:17 | Success | demo     | full          |                  |                    | 04:00:03 |                          
- 20230806230400 | Sun Aug 06 2023 23:04:00 | Failure | demo     | full          |                  | gpbackup_s3_plugin | 00:00:38 |                          
- 20230725110310 | Tue Jul 25 2023 11:03:10 | Success | demo     | incremental   |                  | gpbackup_s3_plugin | 00:00:18 | Wed Jul 26 2023 11:03:28 
- 20230725101959 | Tue Jul 25 2023 10:19:59 | Success | demo     | incremental   |                  | gpbackup_s3_plugin | 00:00:22 |                          
- 20230725101152 | Tue Jul 25 2023 10:11:52 | Success | demo     | incremental   |                  | gpbackup_s3_plugin | 00:00:18 |                          
- 20230725101115 | Tue Jul 25 2023 10:11:15 | Success | demo     | full          |                  | gpbackup_s3_plugin | 00:00:20 |                          
- 20230724090000 | Mon Jul 24 2023 09:00:00 | Success | demo     | metadata-only |                  | gpbackup_s3_plugin | 00:25:17 |                          
- 20230723082000 | Sun Jul 23 2023 08:20:00 | Success | demo     | data-only     |                  | gpbackup_s3_plugin | 00:05:17 |                          
-```
-
-### Delete existing backup (`backup-delete`)
-
-Available options for `backup-delete` command and their description:
-
-```bash
-./gpbackman backup-delete -h
-Delete a specific backup set.
-
-The --timestamp option must be specified. It could be specified multiple times.
-
-By default, the existence of dependent backups is checked and deletion process is not performed,
-unless the --cascade option is passed in.
-
-If backup already deleted, the deletion process is skipped, unless --force option is specified.
-
-By default, he deletion will be performed for local backup (in development).
-
-The storage plugin config file location can be set using the --plugin-config option.
-The full path to the file is required. In this case, the deletion will be performed using the storage plugin.
-
-The gpbackup_history.db file location can be set using the --history-db option.
-Can be specified only once. The full path to the file is required.
-
-The gpbackup_history.yaml file location can be set using the --history-file option.
-Can be specified multiple times. The full path to the file is required.
-
-If no --history-file or --history-db options are specified, the history database will be searched in the current directory.
-
-Only --history-file or --history-db option can be specified, not both.
-
-Usage:
-  gpbackman backup-delete [flags]
-
-Flags:
-      --cascade                 delete all dependent backups for the specified backup timestamp
-      --force                   try to delete, even if the backup already mark as deleted
-  -h, --help                    help for backup-delete
-      --plugin-config string    the full path to plugin config file
-      --timestamp stringArray   the backup timestamp for deleting, could be specified multiple times
-
-Global Flags:
-      --history-db string          full path to the gpbackup_history.db file
-      --history-file stringArray   full path to the gpbackup_history.yaml file, could be specified multiple times
-      --log-file string            full path to log file directory, if not specified, the log file will be created in the $HOME/gpAdminLogs directory
-      --log-level-console string   level for console logging (error, info, debug, verbose) (default "info")
-      --log-level-file string      level for file logging (error, info, debug, verbose) (default "info")
-```
-
-#### Examples
-##### Delete existing backup from local storage
-
-The functionality is in development.
-
-gpBackMan returns a message:
-```bash
-[WARNING]:-The functionality is still in development
-```
-##### Delete existing backup using storage plugin
-Delete specific backup:
-```bash
-./gpbackman backup-delete \
-  --timestamp 20230725101959 \
-  --plugin-config /tmp/gpbackup_plugin_config.yml
-```
-
-Delete specific backup and all dependent backups:
-```bash
-./gpbackman backup-delete\
-  --timestamp 20230725101115 \
-  --plugin-config /tmp/gpbackup_plugin_config.yml \
-  --cascade
-```
-
-### Migrate history database (`history-migrate`)
-
-Available options for `history-migrate` command and their description:
-
-```bash
-./gpbackman history-migrate -h
-Migrate data from gpbackup_history.yaml to gpbackup_history.db SQLite history database.
-
-The data from the gpbackup_history.yaml file will be uploaded to gpbackup_history.db SQLite history database.
-If the gpbackup_history.db file does not exist, it will be created.
-The gpbackup_history.yaml file will be renamed to gpbackup_history.yaml.migrated.
-
-The gpbackup_history.db file location can be set using the  --history-db option.
-Can be specified only once. The full path to the file is required.
-
-The gpbackup_history.yaml file location can be set using the  --history-file option.
-Can be specified multiple times. The full path to the file is required.
-
-If no --history-file and/or --history-db options are specified, the files will be searched in the current directory.
-
-Usage:
-  gpbackman history-migrate [flags]
-
-Flags:
-  -h, --help   help for history-migrate
-
-Global Flags:
-      --history-db string          full path to the gpbackup_history.db file
-      --history-file stringArray   full path to the gpbackup_history.yaml file, could be specified multiple times
-      --log-file string            full path to log file directory, if not specified, the log file will be created in the $HOME/gpAdminLogs directory
-      --log-level-console string   level for console logging (error, info, debug, verbose) (default "info")
-      --log-level-file string      level for file logging (error, info, debug, verbose) (default "info")
-```
-
-#### Examples
-Migrate data from several gpbackup_history.yaml files to gpbackup_history.db SQLite history database:
-```bash
-./gpbackman history-migrate \
-  --history-file /data/master/gpseg-1/gpbackup_history.yaml \
-  --history-file /tmp/gpbackup_history.yaml
-```
+Description of each command:
+* [Delete existing backup (`backup-delete`)](./COMMANDS.md#delete-existing-backup-backup-delete)
+* [Display information about backups (`backup-info`)](./COMMANDS.md#display-information-about-backups-backup-info)
+* [Migrate history database (`history-migrate`)](./COMMANDS.md#migrate-history-database-history-migrate)
+* [Display the backup report (`report-info`)](./COMMANDS.md#display-the-backup-report-report-info)
 
 ## Getting Started
 ### Building and running

--- a/cmd/backup_delete.go
+++ b/cmd/backup_delete.go
@@ -141,7 +141,7 @@ func doDeleteBackup() {
 func backupDeleteDBPlugin(pluginConfig *utils.PluginConfig) {
 	hDB, err := gpbckpconfig.OpenHistoryDB(getHistoryDBPath(rootHistoryDB))
 	if err != nil {
-		gplog.Error(textmsg.ErrorTextUnableOpenHistoryDB(err))
+		gplog.Error(textmsg.ErrorTextUnableActionHistoryDB("open", err))
 		execOSExit(exitErrorCode)
 	}
 	for _, backupName := range backupDeleteTimestamp {

--- a/cmd/backup_delete.go
+++ b/cmd/backup_delete.go
@@ -117,7 +117,6 @@ func doDeleteBackupFlagValidation(flags *pflag.FlagSet) {
 }
 
 func doDeleteBackup() {
-	logHeadersInfo()
 	logHeadersDebug()
 	if len(backupDeletePluginConfigFile) > 0 {
 		pluginConfig, err := utils.ReadPluginConfig(backupDeletePluginConfigFile)

--- a/cmd/backup_delete.go
+++ b/cmd/backup_delete.go
@@ -385,7 +385,7 @@ func checkBackupCanBeDeleted(backupData gpbckpconfig.BackupConfig) bool {
 	// but the storage plugin is not specified. And the deletion is set as local.
 	// Now it is only necessary to check whether the backup is in the local storage.
 	if backupData.IsLocal() {
-		gplog.Error(textmsg.ErrorTextUnableDeleteBackup(backupData.Timestamp, textmsg.ErrorBackupDeleteLocalStorageError()))
+		gplog.Error(textmsg.ErrorTextUnableDeleteBackup(backupData.Timestamp, textmsg.ErrorBackupLocalStorageError()))
 		return result
 	}
 	backupDateDeleted, errDateDeleted := backupData.GetBackupDateDeleted()

--- a/cmd/backup_info.go
+++ b/cmd/backup_info.go
@@ -82,7 +82,7 @@ func doBackupInfo() {
 func backupInfoDB() {
 	hDB, err := gpbckpconfig.OpenHistoryDB(getHistoryDBPath(rootHistoryDB))
 	if err != nil {
-		gplog.Error(textmsg.ErrorTextUnableOpenHistoryDB(err))
+		gplog.Error(textmsg.ErrorTextUnableActionHistoryDB("open", err))
 	}
 	backupList, err := gpbckpconfig.GetBackupNamesDB(backupInfoShowDeleted, backupInfoShowFailed, hDB)
 	if err != nil {

--- a/cmd/constants.go
+++ b/cmd/constants.go
@@ -3,7 +3,12 @@ package cmd
 const (
 	commandName = "gpbackman"
 
+	// Plugin commands.
+	// To be able to work with various plugins,
+	// it is highly desirable to use the commands from the plugin specification.
+	// See https://github.com/greenplum-db/gpbackup/blob/710fe53305958c1faed2e6008b894b4923bed253/plugins/README.md
 	deleteBackupPluginCommand = "delete_backup"
+	restoreDataPluginCommand  = "restore_data"
 
 	historyFileNameBaseConst           = "gpbackup_history"
 	historyFileNameSuffixConst         = ".yaml"

--- a/cmd/history_migrate.go
+++ b/cmd/history_migrate.go
@@ -36,7 +36,6 @@ func init() {
 }
 
 func doMigrateHistory() {
-	logHeadersInfo()
 	logHeadersDebug()
 	hDB, err := history.InitializeHistoryDatabase(getHistoryDBPath(rootHistoryDB))
 	if err != nil {

--- a/cmd/report_info.go
+++ b/cmd/report_info.go
@@ -35,7 +35,7 @@ The --timestamp option must be specified.
 The report could be displayed only for active backups.
 
 The storage plugin config file location can be set using the --plugin-config option.
-The full path to the file is required. In this case, the deletion will be performed using the storage plugin.
+The full path to the file is required.
 
 If a custom plugin is used, it is required to specify the path to the directory with the repo file using the --plugin-report-file-path option.
 It is not necessary to use the --plugin-report-file-path flag for the following plugins (the path is generated automatically):

--- a/cmd/report_info.go
+++ b/cmd/report_info.go
@@ -1,0 +1,254 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/greenplum-db/gp-common-go-libs/gplog"
+	"github.com/greenplum-db/gpbackup/utils"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/woblerr/gpbackman/gpbckpconfig"
+	"github.com/woblerr/gpbackman/textmsg"
+)
+
+const (
+	reportInfoTimestampFlagName            = "timestamp"
+	reportInfoPluginConfigFileFlagName     = "plugin-config"
+	reportInfoReportFilePluginPathFlagName = "plugin-report-file-path"
+)
+
+// Flags for the gpbackman report-info command (reportInfoCmd)
+var (
+	reportInfoTimestamp            string
+	reportInfoPluginConfigFile     string
+	reportInfoReportFilePluginPath string
+)
+
+var reportInfoCmd = &cobra.Command{
+	Use:   "report-info",
+	Short: "Display the report for specific backup set",
+	Long: `Display the report for specific backup set.
+
+The --timestamp option must be specified.
+
+The report could be displayed only for active backups.
+
+The storage plugin config file location can be set using the --plugin-config option.
+The full path to the file is required. In this case, the deletion will be performed using the storage plugin.
+
+If a custom plugin is used, it is required to specify the path to the directory with the repo file using the --plugin-report-file-path option.
+It is not necessary to use the --plugin-report-file-path flag for the following plugins (the path is generated automatically):
+  * gpbackup_s3_plugin,
+
+The gpbackup_history.db file location can be set using the --history-db option.
+Can be specified only once. The full path to the file is required.
+
+The gpbackup_history.yaml file location can be set using the --history-file option.
+Can be specified multiple times. The full path to the file is required.
+
+If no --history-file or --history-db options are specified, the history database will be searched in the current directory.
+
+Only --history-file or --history-db option can be specified, not both.`,
+	Args: cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		doRootFlagValidation(cmd.Flags())
+		doRootBackupFlagValidation(cmd.Flags())
+		doReportInfoFlagValidation(cmd.Flags())
+		doReportInfo()
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(reportInfoCmd)
+	reportInfoCmd.PersistentFlags().StringVar(
+		&reportInfoTimestamp,
+		reportInfoTimestampFlagName,
+		"",
+		"the backup timestamp for report displaying",
+	)
+	reportInfoCmd.PersistentFlags().StringVar(
+		&reportInfoPluginConfigFile,
+		reportInfoPluginConfigFileFlagName,
+		"",
+		"the full path to plugin config file",
+	)
+	reportInfoCmd.PersistentFlags().StringVar(
+		&reportInfoReportFilePluginPath,
+		reportInfoReportFilePluginPathFlagName,
+		"",
+		"the full path to plugin report file",
+	)
+	reportInfoCmd.MarkPersistentFlagRequired(reportInfoTimestampFlagName)
+}
+
+// These flag checks are applied only for report-info command.
+func doReportInfoFlagValidation(flags *pflag.FlagSet) {
+	var err error
+	// If timestamps are specified and have correct values.
+	if flags.Changed(reportInfoTimestampFlagName) {
+		err = gpbckpconfig.CheckTimestamp(reportInfoTimestamp)
+		if err != nil {
+			gplog.Error(textmsg.ErrorTextUnableValidateFlag(reportInfoTimestamp, reportInfoTimestampFlagName, err))
+			execOSExit(exitErrorCode)
+		}
+
+	}
+	// If plugin-config flag is specified and full path.
+	if flags.Changed(reportInfoPluginConfigFileFlagName) {
+		err = gpbckpconfig.CheckFullPath(reportInfoPluginConfigFile)
+		if err != nil {
+			gplog.Error(textmsg.ErrorTextUnableValidateFlag(reportInfoPluginConfigFile, reportInfoPluginConfigFileFlagName, err))
+			execOSExit(exitErrorCode)
+		}
+	}
+	// If plugin-report-file-pat flag is specified and full path.
+	if flags.Changed(reportInfoReportFilePluginPathFlagName) {
+		err = gpbckpconfig.CheckFullPath(reportInfoReportFilePluginPath)
+		if err != nil {
+			gplog.Error(textmsg.ErrorTextUnableValidateFlag(reportInfoReportFilePluginPath, reportInfoReportFilePluginPathFlagName, err))
+			execOSExit(exitErrorCode)
+		}
+	}
+}
+
+func doReportInfo() {
+	logHeadersDebug()
+	if len(reportInfoPluginConfigFile) > 0 {
+		pluginConfig, err := utils.ReadPluginConfig(reportInfoPluginConfigFile)
+		if err != nil {
+			gplog.Error(textmsg.ErrorTextUnableReadPluginConfigFile(err))
+			execOSExit(exitErrorCode)
+		}
+		if historyDB {
+			reportInfoDBPlugin(pluginConfig)
+		} else {
+			reportInfoFilePlugin(pluginConfig)
+		}
+	} else {
+		if historyDB {
+			reportInfoDBLocal()
+		} else {
+			reportInfoFileLocal()
+		}
+	}
+}
+
+func reportInfoDBPlugin(pluginConfig *utils.PluginConfig) {
+	hDB, err := gpbckpconfig.OpenHistoryDB(getHistoryDBPath(rootHistoryDB))
+	if err != nil {
+		gplog.Error(textmsg.ErrorTextUnableOpenHistoryDB(err))
+		execOSExit(exitErrorCode)
+	}
+	backupName := reportInfoTimestamp
+	backupData, err := gpbckpconfig.GetBackupDataDB(backupName, hDB)
+	if err != nil {
+		gplog.Error(textmsg.ErrorTextUnableGetBackupInfo(backupName, err))
+	}
+	if checkBackupCanGetReport(backupData) {
+		reportInfoPluginFunc(backupData, pluginConfig)
+	}
+	hDB.Close()
+}
+
+// TODO
+func reportInfoFilePlugin(pluginConfig *utils.PluginConfig) {
+	for _, historyFile := range rootHistoryFiles {
+		hFile := getHistoryFilePath(historyFile)
+		historyData, err := gpbckpconfig.ReadHistoryFile(hFile)
+		if err != nil {
+			gplog.Error(textmsg.ErrorTextUnableActionHistoryFile("read", err))
+			continue
+		}
+		parseHData, err := gpbckpconfig.ParseResult(historyData)
+		if err != nil {
+			gplog.Error(textmsg.ErrorTextUnableActionHistoryFile("parse", err))
+			continue
+		}
+		if len(parseHData.BackupConfigs) != 0 {
+			backupName := reportInfoTimestamp
+			_, backupData, err := parseHData.FindBackupConfig(backupName)
+			if err != nil {
+				gplog.Error(textmsg.ErrorTextUnableGetBackupInfo(backupName, err))
+				continue
+			}
+			if checkBackupCanGetReport(backupData) {
+				reportInfoPluginFunc(backupData, pluginConfig)
+			}
+		}
+	}
+}
+
+func reportInfoPluginFunc(backupData gpbckpconfig.BackupConfig, pluginConfig *utils.PluginConfig) {
+	reportFile, err := backupData.GetReportFilePathPlugin(reportInfoReportFilePluginPath, pluginConfig.Options)
+	if err != nil {
+		gplog.Error(textmsg.ErrorTextUnableGetBackupReportPath(backupData.Timestamp, err))
+	}
+	stdout, stderr, err := execReportInfo(pluginConfig.ExecutablePath, restoreDataPluginCommand, reportInfoPluginConfigFile, reportFile)
+	if len(stderr) > 0 {
+		gplog.Error(stderr)
+	}
+	if err != nil {
+		gplog.Error(textmsg.ErrorTextUnableGetBackupReport(backupData.Timestamp, err))
+	}
+	// Display the report.
+	fmt.Println(stdout)
+}
+
+// TODO
+func reportInfoDBLocal() {
+	gplog.Warn("The functionality is still in development")
+}
+
+// TODO
+func reportInfoFileLocal() {
+	gplog.Warn("The functionality is still in development")
+}
+
+// Report could be displayed only for active backups:
+// - backup has success status and backup is active
+// Returns:
+// - true, if report can be displayed;
+// - false, if report can't be displayed.
+// Errors and warnings will also be logged.
+func checkBackupCanGetReport(backupData gpbckpconfig.BackupConfig) bool {
+	result := false
+	backupSuccessStatus, err := backupData.IsSuccess()
+	if err != nil {
+		gplog.Error(textmsg.ErrorTextUnableGetBackupValue("status", backupData.Timestamp, err))
+		return result
+	}
+	if !backupSuccessStatus {
+		gplog.Warn(textmsg.WarnTextBackupFailedStatus(backupData.Timestamp))
+		return result
+	}
+	// Checks, if this is local backup.
+	if backupData.IsLocal() {
+		gplog.Error(textmsg.ErrorTextUnableGetBackupReport(backupData.Timestamp, textmsg.ErrorBackupLocalStorageError()))
+		return result
+	}
+	backupDateDeleted, errDateDeleted := backupData.GetBackupDateDeleted()
+	if errDateDeleted != nil {
+		gplog.Error(textmsg.ErrorTextUnableGetBackupValue("date deletion", backupData.Timestamp, errDateDeleted))
+	}
+	// If the backup date deletion has invalid value, try to delete the backup.
+	if gpbckpconfig.IsBackupActive(backupDateDeleted) || errDateDeleted != nil {
+		result = true
+	} else {
+		if backupDateDeleted == gpbckpconfig.DateDeletedInProgress {
+			gplog.Warn(textmsg.ErrorTextBackupDeleteInProgress(backupData.Timestamp, textmsg.ErrorBackupDeleteInProgressError()))
+		} else {
+			gplog.Warn(textmsg.WarnTextBackupAlreadyDeleted(backupData.Timestamp))
+		}
+	}
+	return result
+}
+
+func execReportInfo(executablePath, reportInfoPluginCommand, pluginConfigFile, file string) (string, string, error) {
+	cmd := execCommand(executablePath, reportInfoPluginCommand, pluginConfigFile, file)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	return stdout.String(), stderr.String(), err
+}

--- a/cmd/wrappers.go
+++ b/cmd/wrappers.go
@@ -15,14 +15,11 @@ import (
 
 var execOSExit = os.Exit
 
-func logHeadersInfo() {
-	gplog.Info("Start %s version %s", commandName, getVersion())
-	gplog.Info("Use console log level: %s", rootLogLevelConsole)
-	gplog.Info("Use file log level: %s", rootLogLevelFile)
-}
-
 func logHeadersDebug() {
-	gplog.Verbose("%s command: %s", commandName, os.Args)
+	gplog.Debug("Start %s version %s", commandName, getVersion())
+	gplog.Debug("Use console log level: %s", rootLogLevelConsole)
+	gplog.Debug("Use file log level: %s", rootLogLevelFile)
+	gplog.Debug("%s command: %s", commandName, os.Args)
 }
 
 // Sets the log levels for the console and file loggers.

--- a/e2e_tests/docker-compose.yml
+++ b/e2e_tests/docker-compose.yml
@@ -2,20 +2,7 @@ version: '3'
 
 services:
   ################################################################
-  # Test backup-info command.
-  backup-info:
-    image: ${IMAGE_GPBACKMAN}
-    container_name: backup-info
-    hostname: backup-info
-    volumes:
-      - "./src_data:/home/gpbackman/src_data"
-      - "./scripts/run_backup-info.sh:/home/gpbackman/run_backup-info.sh"
-    command: /home/gpbackman/run_backup-info.sh
-    networks:
-      - e2e
-
-  ################################################################
-  # Test backup-delete command.
+  # Prepare infra for some tests.
   minio:
     image: minio/minio:${IMAGE_TAG_MINIO}
     container_name: minio
@@ -32,9 +19,9 @@ services:
     networks:
       - e2e
 
-  prepare_backup-delete:
+  prepare_minio:
     image: minio/mc:${IMAGE_TAG_MINIO_MC}
-    container_name: prepate_backup-delete
+    container_name: prepare_minio
     environment:
       - "MINIO_ROOT_USER"
       - "MINIO_ROOT_PASSWORD"
@@ -46,11 +33,27 @@ services:
       minio:
         condition: service_started
     volumes:
-      - "./scripts/prepare_backup-delete.sh:/prepare_backup-delete.sh"
-    entrypoint: /prepare_backup-delete.sh
+      - "./scripts/prepare_minio.sh:/prepare_minio.sh"
+      - "./src_data:/tmp/src_data"
+    entrypoint: /prepare_minio.sh
     networks:
       - e2e
 
+################################################################
+  # Test backup-info command.
+  backup-info:
+    image: ${IMAGE_GPBACKMAN}
+    container_name: backup-info
+    hostname: backup-info
+    volumes:
+      - "./src_data:/home/gpbackman/src_data"
+      - "./scripts/run_backup-info.sh:/home/gpbackman/run_backup-info.sh"
+    command: /home/gpbackman/run_backup-info.sh
+    networks:
+      - e2e
+
+  ################################################################
+  # Test backup-delete command.
   backup-delete:
     build:
       context: .
@@ -63,7 +66,7 @@ services:
     depends_on:
       minio:
         condition: service_started
-      prepare_backup-delete:
+      prepare_minio:
         condition: service_completed_successfully
     volumes:
       - "./src_data:/home/gpbackman/src_data"
@@ -83,6 +86,30 @@ services:
       - "./src_data:/home/gpbackman/src_data"
       - "./scripts/run_history-migrate.sh:/home/gpbackman/run_history-migrate.sh"
     command: /home/gpbackman/run_history-migrate.sh
+    networks:
+      - e2e
+
+  ################################################################
+  # Test report-info command.
+  report-info:
+    build:
+      context: .
+      dockerfile: ./conf/Dockerfile.s3_plugin
+      args:
+        S3_PLUGIN_VERSION: ${S3_PLUGIN_VERSION}
+    image: report-info
+    container_name: report-info
+    hostname: report-info
+    depends_on:
+      minio:
+        condition: service_started
+      prepare_minio:
+        condition: service_completed_successfully
+    volumes:
+      - "./src_data:/home/gpbackman/src_data"
+      - "./scripts/run_report-info.sh:/home/gpbackman/run_report-info.sh"
+      - "./conf/gpbackup_s3_plugin.yaml:/home/gpbackman/gpbackup_s3_plugin.yaml"
+    command: /home/gpbackman/run_report-info.sh
     networks:
       - e2e
 

--- a/e2e_tests/scripts/prepare_minio.sh
+++ b/e2e_tests/scripts/prepare_minio.sh
@@ -10,6 +10,7 @@ mc admin policy attach ${S3_MINIO_HOSTNAME} readwrite --user ${S3_MINIO_KEY}
 TIMESTAMP="20230724090000"
 touch /tmp/test.txt
 mc cp /tmp/test.txt ${S3_MINIO_HOSTNAME}/${S3_MINIO_BUCKET}/test/backups/${TIMESTAMP:0:8}/${TIMESTAMP}/test.txt
+mc cp /tmp/src_data/gpbackup_${TIMESTAMP}_report ${S3_MINIO_HOSTNAME}/${S3_MINIO_BUCKET}/test/backups/${TIMESTAMP:0:8}/${TIMESTAMP}/gpbackup_${TIMESTAMP}_report
 
 TIMESTAMPS="20230725101959 20230725102950 20230725102831"
 for i in ${TIMESTAMPS}; do

--- a/e2e_tests/scripts/run_report-info.sh
+++ b/e2e_tests/scripts/run_report-info.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+
+# Local image for e2e tests should be built before running tests.
+# See make file for details.
+# This test works with files from src_data directory.
+# If new file with backup info is added to src_data, it's nessary to update test cases in this script.
+
+GPBACKMAN_TEST_COMMAND="report-info"
+
+HOME_DIR="/home/gpbackman"
+SRC_DIR="${HOME_DIR}/src_data"
+WORK_DIR="${HOME_DIR}/test_data"
+
+TIMESTAMP="20230724090000"
+
+# Prepare data.
+rm -rf "${WORK_DIR}/"
+mkdir -p "${WORK_DIR}"
+cp ${SRC_DIR}/gpbackup_history_metadata_plugin.yaml \
+${SRC_DIR}/gpbackup_history.db \
+${WORK_DIR}
+
+################################################################
+# Test 1.
+# Get report info for specified backup.
+
+# Execute report-info commnad.
+GPBACKMAN_RESULT_YAML=$(gpbackman ${GPBACKMAN_TEST_COMMAND} \
+--history-file ${WORK_DIR}/gpbackup_history_metadata_plugin.yaml \
+--timestamp ${TIMESTAMP} \
+--plugin-config ${HOME_DIR}/gpbackup_s3_plugin.yaml | grep -v 'Reading Plugin Config')
+
+GPBACKMAN_RESULT_SQLITE=$(gpbackman ${GPBACKMAN_TEST_COMMAND} \
+--history-db ${WORK_DIR}/gpbackup_history.db \
+--timestamp ${TIMESTAMP} \
+--plugin-config ${HOME_DIR}/gpbackup_s3_plugin.yaml | grep -v 'Reading Plugin Config')
+
+# Check results.
+echo "[INFO] ${GPBACKMAN_TEST_COMMAND} test 1."
+bckp_report=$(cat ${SRC_DIR}/gpbackup_${TIMESTAMP}_report)
+if [ "${bckp_report}" != "${GPBACKMAN_RESULT_YAML}" ] ||  [ "${bckp_report}" != "${GPBACKMAN_RESULT_SQLITE}" ]; then
+    echo -e "[ERROR] results do not match.\nbckp_report:\n${bckp_report}\nget_yaml:\n${GPBACKMAN_RESULT_YAML}\nget_sqlite:\n${GPBACKMAN_RESULT_SQLITE}"
+    exit 1
+fi
+echo "[INFO] ${GPBACKMAN_TEST_COMMAND} test 1 passed."
+
+echo "[INFO] ${GPBACKMAN_TEST_COMMAND} all tests passed"
+exit 0

--- a/e2e_tests/src_data/gpbackup_20230724090000_report
+++ b/e2e_tests/src_data/gpbackup_20230724090000_report
@@ -1,0 +1,59 @@
+Greenplum Database Backup Report
+
+timestamp key:         20230724090000
+gpdb version:          6.23.3
+gpbackup version:      1.27.0
+
+database name:         demo
+command line:          gpbackup --dbname demo --compression-type gzip --plugin-config /tmp/gpbackup_plugin_config.yml --metadata-only
+compression:           gzip
+plugin executable:     gpbackup_s3_plugin
+backup section:        Metadata Only
+object filtering:      None
+includes statistics:   No
+data file format:      No Data Files
+incremental:           False
+
+start time:            Mon Jul 24 2023 09:00:00
+end time:              Mon Jul 24 2023 09:05:17
+duration:              0:05:17
+
+backup status:         Success
+
+segment count:         8
+
+count of database objects in backup:
+aggregates                   50
+casts                        8
+collations                   0
+constraints                  100
+conversions                  0
+default privileges           60
+database gucs                0
+event triggers               0
+extensions                   10
+foreign data wrappers        0
+foreign servers              0
+functions                    100
+indexes                      5
+operator classes             1
+operator families            1
+operators                    10
+procedural languages         1
+protocols                    1
+resource groups              3
+resource queues              1
+roles                        200
+rules                        0
+schemas                      70
+sequences                    15
+tables                       1000
+tablespaces                  0
+text search configurations   0
+text search dictionaries     0
+text search parsers          0
+text search templates        0
+triggers                     0
+types                        60
+user mappings                0
+views                        500

--- a/gpbckpconfig/struct.go
+++ b/gpbckpconfig/struct.go
@@ -70,6 +70,8 @@ const (
 	DateDeletedInProgress   = "In progress"
 	DateDeletedPluginFailed = "Plugin Backup Delete Failed"
 	DateDeletedLocalFailed  = "Local Delete Failed"
+	// Plugin names.
+	backupS3Plugin = "gpbackup_s3_plugin"
 )
 
 // GetBackupType Get backup type.
@@ -215,6 +217,23 @@ func (backupConfig BackupConfig) IsSuccess() (bool, error) {
 //   - false - if the backup in plugin storage (plugin field is not empty).
 func (backupConfig BackupConfig) IsLocal() bool {
 	return backupConfig.Plugin == ""
+}
+
+// GetReportFilePathPlugin Return path to report file name for specific plugin.
+// If custom report path is set, it is returned.
+// Otherwise, the path from plugin is returned.
+func (backupConfig BackupConfig) GetReportFilePathPlugin(customReportPath string, pluginOptions map[string]string) (string, error) {
+	if customReportPath != "" {
+		return backupPluginCustomReportPath(backupConfig.Timestamp, customReportPath), nil
+	}
+	// In future another plugins may be added.
+	switch backupConfig.Plugin {
+	case backupS3Plugin:
+		return backupS3PluginReportPath(backupConfig.Timestamp, pluginOptions)
+	default:
+		// nothing to do
+	}
+	return "", errors.New("the path to the report is not specified")
 }
 
 func (history *History) FindBackupConfig(timestamp string) (int, BackupConfig, error) {

--- a/gpbckpconfig/struct_test.go
+++ b/gpbckpconfig/struct_test.go
@@ -398,6 +398,109 @@ func TestIsLocal(t *testing.T) {
 	}
 }
 
+func TestBackupConfigGetReportFilePathPlugin(t *testing.T) {
+
+	type args struct {
+		customReportPath string
+		pluginOptions    map[string]string
+	}
+	tests := []struct {
+		name    string
+		config  BackupConfig
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "Test custom report path",
+			config: BackupConfig{
+				Timestamp: "20220401102430",
+				Plugin:    backupS3Plugin,
+			},
+			args: args{
+				customReportPath: "/path/to/report",
+				pluginOptions:    make(map[string]string),
+			},
+			want:    "/path/to/report/gpbackup_20220401102430_report",
+			wantErr: false,
+		},
+		{
+			name: "Test s3 plugin report path if custom report path is not set and folder is absent",
+			config: BackupConfig{
+				Timestamp: "20220401102430",
+				Plugin:    backupS3Plugin,
+			},
+			args: args{
+				customReportPath: "",
+				pluginOptions: map[string]string{
+					"bucket": "bucket",
+				},
+			},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name: "Test s3 plugin report path if custom report path is not set and folder is empty",
+			config: BackupConfig{
+				Timestamp: "20220401102430",
+				Plugin:    backupS3Plugin,
+			},
+			args: args{
+				customReportPath: "",
+				pluginOptions: map[string]string{
+					"folder": "",
+				},
+			},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name: "Test s3 plugin report path if custom report path is not set and folder is ok",
+			config: BackupConfig{
+				Timestamp: "20220401102430",
+				Plugin:    backupS3Plugin,
+			},
+
+			args: args{
+				customReportPath: "",
+				pluginOptions: map[string]string{
+					"folder": "/path/to/report",
+				},
+			},
+			want:    "/path/to/report/backups/20220401/20220401102430/gpbackup_20220401102430_report",
+			wantErr: false,
+		},
+		{
+			name: "Test some plugin report path if custom report path is not set",
+			config: BackupConfig{
+				Timestamp: "20220401102430",
+				Plugin:    "some_plugin",
+			},
+
+			args: args{
+				customReportPath: "",
+				pluginOptions: map[string]string{
+					"folder": "/path/to/report",
+				},
+			},
+			want:    "",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.config.GetReportFilePathPlugin(tt.args.customReportPath, tt.args.pluginOptions)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("\nBackupConfig.GetReportFilePathPlugin()error:\n%v\nwantErr:\n%v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("\nBackupConfig.GetReportFilePathPlugin() got:\n%v\nwant:%v\ns", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestFindBackupConfig(t *testing.T) {
 	historyTest := &History{
 		BackupConfigs: []BackupConfig{

--- a/gpbckpconfig/utils.go
+++ b/gpbckpconfig/utils.go
@@ -3,6 +3,7 @@ package gpbckpconfig
 import (
 	"path/filepath"
 	"regexp"
+	"strings"
 
 	"github.com/woblerr/gpbackman/textmsg"
 )
@@ -29,4 +30,39 @@ func IsBackupActive(dateDeleted string) bool {
 	return (dateDeleted == "" ||
 		dateDeleted == DateDeletedPluginFailed ||
 		dateDeleted == DateDeletedLocalFailed)
+}
+
+// backupPluginCustomReportPath Returns custom report path:
+//
+//	<folder>/gpbackup_<YYYYMMDDHHMMSS>_report
+func backupPluginCustomReportPath(timestamp, folderValue string) string {
+	return filepath.Join("/", folderValue, reportFileName(timestamp))
+}
+
+// backupS3PluginReportPath Returns path to report file name for gpbackup_s3_plugin plugin.
+// Basic path for s3 plugin format:
+//
+//	<folder>/backups/<YYYYMMDD>/<YYYYMMDDHHMMSS>/gpbackup_<YYYYMMDDHHMMSS>_report
+//
+// See GetS3Path() func in https://github.com/greenplum-db/gpbackup-s3-plugin.
+// If folder option is not specified or it is empty, the error will be returned.
+func backupS3PluginReportPath(timestamp string, pluginOptions map[string]string) (string, error) {
+	pathOption := "folder"
+	reportPathBasic := "backups/" + timestamp[0:8] + "/" + timestamp
+	folderValue, exists := pluginOptions[pathOption]
+	if !exists || folderValue == "" {
+		return "", textmsg.ErrorValidationPluginOption(pathOption, backupS3Plugin)
+	}
+	// It's necessary to return full path to report file with leading '/'.
+	// But in config file folder value could be with leading '/' or without.
+	// So we need to remove leading '/' and add it back.
+	folderValue = strings.TrimPrefix(folderValue, "/")
+	folderValue = strings.TrimSuffix(folderValue, "/")
+	return filepath.Join("/", folderValue, reportPathBasic, reportFileName(timestamp)), nil
+}
+
+// reportFileName Returns report file name for specific timestamp.
+// Report file name format: gpbackup_<YYYYMMDDHHMMSS>_report.
+func reportFileName(timestamp string) string {
+	return "gpbackup_" + timestamp + "_report"
 }

--- a/gpbckpconfig/utils.go
+++ b/gpbckpconfig/utils.go
@@ -48,6 +48,8 @@ func backupPluginCustomReportPath(timestamp, folderValue string) string {
 // If folder option is not specified or it is empty, the error will be returned.
 func backupS3PluginReportPath(timestamp string, pluginOptions map[string]string) (string, error) {
 	pathOption := "folder"
+	// Timestamp validation is done on flags validation.
+	// We assume, that is the correct value coming from.
 	reportPathBasic := "backups/" + timestamp[0:8] + "/" + timestamp
 	folderValue, exists := pluginOptions[pathOption]
 	if !exists || folderValue == "" {

--- a/textmsg/error.go
+++ b/textmsg/error.go
@@ -10,8 +10,8 @@ import (
 
 // Errors that occur when working with a history db.
 
-func ErrorTextUnableOpenHistoryDB(err error) string {
-	return fmt.Sprintf("Unable to open history db. Error: %v", err)
+func ErrorTextUnableActionHistoryDB(value string, err error) string {
+	return fmt.Sprintf("Unable to %s history db. Error: %v", value, err)
 }
 
 func ErrorTextUnableReadHistoryDB(err error) string {

--- a/textmsg/error.go
+++ b/textmsg/error.go
@@ -62,6 +62,14 @@ func ErrorTextBackupDeleteInProgress(backupName string, err error) string {
 	return fmt.Sprintf("Backup %s deletion in progress. Error: %v", backupName, err)
 }
 
+func ErrorTextUnableGetBackupReport(backupName string, err error) string {
+	return fmt.Sprintf("Unable to get report for the backup %s. Error: %v", backupName, err)
+}
+
+func ErrorTextUnableGetBackupReportPath(backupName string, err error) string {
+	return fmt.Sprintf("Unable to get path to report for the backup %s. Error: %v", backupName, err)
+}
+
 // Errors that occur when working with a backup plugin.
 
 func ErrorTextUnableReadPluginConfigFile(err error) string {
@@ -119,7 +127,7 @@ func ErrorBackupDeleteCascadeOptionError() error {
 	return errors.New("use cascade option")
 }
 
-func ErrorBackupDeleteLocalStorageError() error {
+func ErrorBackupLocalStorageError() error {
 	return errors.New("is a local backup")
 }
 
@@ -131,4 +139,10 @@ func ErrorValidationFullPath() error {
 
 func ErrorValidationTimestamp() error {
 	return errors.New("not a timestamp")
+}
+
+// Error that is returned when some plugin options validation fails
+
+func ErrorValidationPluginOption(value, pluginName string) error {
+	return fmt.Errorf("invalid plugin %s option value for plugin %s", value, pluginName)
 }

--- a/textmsg/error_test.go
+++ b/textmsg/error_test.go
@@ -206,7 +206,7 @@ func TestErrorFunctions(t *testing.T) {
 		{"ErrorBackupDeleteCascadeOptionError", ErrorBackupDeleteCascadeOptionError, "use cascade option"},
 		{"ErrorValidationFullPath", ErrorValidationFullPath, "not an absolute path"},
 		{"ErrorValidationTimestamp", ErrorValidationTimestamp, "not a timestamp"},
-		{"ErrorBackupDeleteLocalStorageError", ErrorBackupDeleteLocalStorageError, "is a local backup"},
+		{"ErrorBackupLocalStorageError", ErrorBackupLocalStorageError, "is a local backup"},
 	}
 
 	for _, tt := range tests {

--- a/textmsg/error_test.go
+++ b/textmsg/error_test.go
@@ -14,12 +14,6 @@ func TestErrorTextFunctionsErrorOnly(t *testing.T) {
 		want     string
 	}{
 		{
-			name:     "Test ErrorTextUnableOpenHistoryDB",
-			testErr:  testError,
-			function: ErrorTextUnableOpenHistoryDB,
-			want:     "Unable to open history db. Error: test error",
-		},
-		{
 			name:     "Test ErrorTextUnableReadHistoryDB",
 			testErr:  testError,
 			function: ErrorTextUnableReadHistoryDB,
@@ -118,6 +112,13 @@ func TestErrorTextFunctionsErrorAndArg(t *testing.T) {
 			testErr:  testError,
 			function: ErrorTextUnableGetBackupReportPath,
 			want:     "Unable to get path to report for the backup TestBackup. Error: test error",
+		},
+		{
+			name:     "Test ErrorTextUnableActionHistoryDB",
+			value:    "open",
+			testErr:  testError,
+			function: ErrorTextUnableActionHistoryDB,
+			want:     "Unable to open history db. Error: test error",
 		},
 	}
 	for _, tt := range tests {

--- a/textmsg/error_test.go
+++ b/textmsg/error_test.go
@@ -105,6 +105,20 @@ func TestErrorTextFunctionsErrorAndArg(t *testing.T) {
 			function: ErrorTextUnableActionHistoryFile,
 			want:     "Unable to do something with history file. Error: test error",
 		},
+		{
+			name:     "Test ErrorTextUnableGetBackupReport",
+			value:    testBackupName,
+			testErr:  testError,
+			function: ErrorTextUnableGetBackupReport,
+			want:     "Unable to get report for the backup TestBackup. Error: test error",
+		},
+		{
+			name:     "Test ErrorTextUnableGetBackupReportPath",
+			value:    testBackupName,
+			testErr:  testError,
+			function: ErrorTextUnableGetBackupReportPath,
+			want:     "Unable to get path to report for the backup TestBackup. Error: test error",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -194,9 +208,9 @@ func TestErrorTextFunctionsErrorAndMultipleArgs(t *testing.T) {
 
 func TestErrorFunctions(t *testing.T) {
 	tests := []struct {
-		name     string
-		errFunc  func() error
-		expected string
+		name    string
+		errFunc func() error
+		want    string
 	}{
 		{"ErrorInvalidValueError", ErrorInvalidValueError, "invalid flag value"},
 		{"ErrorIncompatibleValuesError", ErrorIncompatibleValuesError, "incompatible flags values"},
@@ -212,9 +226,33 @@ func TestErrorFunctions(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := tt.errFunc()
-			if err == nil || err.Error() != tt.expected {
-				t.Errorf("\n%s() error:\n%v\nwant:\n%v", tt.name, err, tt.expected)
+			if err == nil || err.Error() != tt.want {
+				t.Errorf("\n%s() error:\n%v\nwant:\n%v", tt.name, err, tt.want)
 			}
 		})
+	}
+}
+
+func TestErrorFunctionsTwoArgs(t *testing.T) {
+	tests := []struct {
+		name    string
+		value1  string
+		value2  string
+		errFunc func(string, string) error
+		want    string
+	}{
+		{
+			name:    "ErrorValidationPluginOption",
+			value1:  "TestValue1",
+			value2:  "TestValue2",
+			errFunc: ErrorValidationPluginOption,
+			want:    "invalid plugin TestValue1 option value for plugin TestValue2",
+		},
+	}
+	for _, tt := range tests {
+		err := tt.errFunc(tt.value1, tt.value2)
+		if err == nil || err.Error() != tt.want {
+			t.Errorf("\n%s() error:\n%v\nwant:\n%v", tt.name, err, tt.want)
+		}
 	}
 }

--- a/textmsg/warn.go
+++ b/textmsg/warn.go
@@ -9,3 +9,7 @@ func WarnTextBackupAlreadyDeleted(backupName string) string {
 func WarnTextBackupFailedStatus(backupName string) string {
 	return fmt.Sprintf("Backup %s has failed status. Nothing to do", backupName)
 }
+
+func WarnTextBackupUnableGetReport(backupName string) string {
+	return fmt.Sprintf("Unable to get report for backup %s. Check if backup is active", backupName)
+}

--- a/textmsg/warn_test.go
+++ b/textmsg/warn_test.go
@@ -23,6 +23,12 @@ func TestWarnTextFunctionsWarnAndArg(t *testing.T) {
 			function: WarnTextBackupFailedStatus,
 			want:     "Backup TestBackup has failed status. Nothing to do",
 		},
+		{
+			name:     "Test WarnTextBackupUnableGetReport",
+			value:    "TestBackup",
+			function: WarnTextBackupUnableGetReport,
+			want:     "Unable to get report for backup TestBackup. Check if backup is active",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Added`report-info` command for displaying report file.

Current functional works with gpbackup plugins (basically, with `gpbackup_s3_plugin`).

For `gpbackup_s3_plugin` it's enough to specify a valid config for the plugin.
For other plugins, it is needed  to specify the full path in the repository to the folder with the file report (`--plugin-report-file-path` flag).

Process based on `restore_data` command from gpbackup plugins specification.

Information about program version, executed commandant and etc.  was moved on debug log level, not on info.

The documentation has been refactored:
* moved commands description to separate file COMMANDS.md;
* added links for each command to README.md.

Aded e2e test for `report-info` command, which  compares the contents of the report file from the src_data directory with the result of the report-info command.

Also some refactoring compose file and Makefile. Now, when running e2e tests, a complete test environment is always prepared for each team. So that there are no intersections.