### PR TITLE
Fix incorrect backup type for backups without tables containing data.

### DIFF
--- a/gpbckpconfig/struct.go
+++ b/gpbckpconfig/struct.go
@@ -81,23 +81,26 @@ const (
 //   - metadata-only – contains only global and local metadata for the database;
 //   - data-only – contains only user data from the database.
 //
-// For gpbackup you cannot combine --data-only or --metadata-only with --incremental (see docs).
-// So these options cannot be set at the same time.
-// If not one of the --data-only, --metadata-only and --incremental flags is not set,
-// the full value is returned.
-// But if the --data-only flag set, or it's full backup, but there are no tables in backup set contain data,
-// the metadata-only value is returned.
-// See https://github.com/greenplum-db/gpbackup/blob/b061a47b673238439442340e66ca57d896edacd5/backup/backup.go#L127-L129
 // In all other cases, an error is returned.
 func (backupConfig BackupConfig) GetBackupType() (string, error) {
+	// For gpbackup you cannot combine --data-only or --metadata-only with --incremental (see docs).
+	// So these options cannot be set at the same time.
+	// If not one of the --data-only, --metadata-only and --incremental flags is not set,
+	// the full value is returned.
+	// But if there are no tables in backup set contain data,
+	// the metadata-only value is returned.
+	// See https://github.com/woblerr/gpbackup/blob/b061a47b673238439442340e66ca57d896edacd5/backup/backup.go#L127-L129
 	switch {
-	case !(backupConfig.Incremental || backupConfig.DataOnly || backupConfig.MetadataOnly):
+	case !backupConfig.Incremental && !backupConfig.DataOnly && !backupConfig.MetadataOnly:
 		return BackupTypeFull, nil
-	case backupConfig.Incremental && !(backupConfig.DataOnly || backupConfig.MetadataOnly):
+	case backupConfig.Incremental && !backupConfig.DataOnly && !backupConfig.MetadataOnly:
 		return BackupTypeIncremental, nil
-	case backupConfig.DataOnly && !(backupConfig.Incremental || backupConfig.MetadataOnly):
+	case backupConfig.DataOnly && !backupConfig.Incremental && !backupConfig.MetadataOnly:
 		return BackupTypeDataOnly, nil
-	case backupConfig.MetadataOnly && !(backupConfig.Incremental):
+	// If only metadata-only value.
+	// Or combination metadata-only and incremental or metadata-only and data-only.
+	// The case when there are no tables in backup set contain data.
+	case (backupConfig.MetadataOnly && !backupConfig.Incremental) || (backupConfig.MetadataOnly && !backupConfig.DataOnly):
 		return BackupTypeMetadataOnly, nil
 	default:
 		return "", errors.New("backup type does not match any of the available values")

--- a/gpbckpconfig/struct_test.go
+++ b/gpbckpconfig/struct_test.go
@@ -53,6 +53,16 @@ func TestGetBackupType(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "Test metadata-only when no data in regular incremental backup",
+			config: BackupConfig{
+				Incremental:  true,
+				DataOnly:     false,
+				MetadataOnly: true,
+			},
+			want:    BackupTypeMetadataOnly,
+			wantErr: false,
+		},
+		{
 			name: "Test full backup",
 			config: BackupConfig{
 				Incremental:  false,


### PR DESCRIPTION
There are cases when an incremental or data-only backup was performed, but there were no tables containing data in the backup set.

In such cases, a metadata-only backup is performed, but both flags are set (metadata-only and incremental or metadata-only and data-only).

A case metadata-only and incremental was missed.