### PR TITLE
Refactoring the backup deletion process to cleanup backup info on master host.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,14 @@ jobs:
         run: echo ${{ steps.buildx.outputs.platforms }}
 
       - name: Run end-to-end tests
+        env:
+          GITHUB_USER: ${{ github.actor }}
+          GITHUB_PKG: ${{ secrets.GUTHUB_CR_PAT }}
+          DOCKERHUB_USER: ${{ secrets.DOCKEHUB_USER }}
+          DOCKERHUB_PKG: ${{ secrets.DOCKEHUB_TOKEN }}
         run: |
+          echo ${GITHUB_PKG} | docker login ghcr.io -u ${GITHUB_USER} --password-stdin
+          echo ${DOCKERHUB_PKG} | docker login -u ${DOCKERHUB_USER} --password-stdin
           make test-e2e
 
       - name: Build image and push master tag to ghcr.io and Docker Hub

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,9 +54,9 @@ jobs:
       - name: Available platforms
         run: echo ${{ steps.buildx.outputs.platforms }}
 
-      - name: Run end-to-end tests
-        run: |
-          make test-e2e
+      # - name: Run end-to-end tests
+      #   run: |
+      #     make test-e2e
 
       - name: Build image and push master tag to ghcr.io and Docker Hub
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,14 +55,7 @@ jobs:
         run: echo ${{ steps.buildx.outputs.platforms }}
 
       - name: Run end-to-end tests
-        env:
-          GITHUB_USER: ${{ github.actor }}
-          GITHUB_PKG: ${{ secrets.GUTHUB_CR_PAT }}
-          DOCKERHUB_USER: ${{ secrets.DOCKEHUB_USER }}
-          DOCKERHUB_PKG: ${{ secrets.DOCKEHUB_TOKEN }}
         run: |
-          echo ${GITHUB_PKG} | docker login ghcr.io -u ${GITHUB_USER} --password-stdin
-          echo ${DOCKERHUB_PKG} | docker login -u ${DOCKERHUB_USER} --password-stdin
           make test-e2e
 
       - name: Build image and push master tag to ghcr.io and Docker Hub

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -12,10 +12,10 @@
 - [Display information about backups (`backup-info`)](#display-information-about-backups-backup-info)
   - [Examples](#examples-2)
   - [Using container](#using-container-2)
-- [Clean failed and deleted backups from the history database (`history-clean`)](#clean-failed-and-deleted-backups-from-the-history-database-history-clean)
+- [Clean deleted backups from the history database (`history-clean`)](#clean-deleted-backups-from-the-history-database-history-clean)
   - [Examples](#examples-3)
-    - [Delete information about failed and deleted backups from history database older than n days](#delete-information-about-failed-and-deleted-backups-from-history-database-older-than-n-days)
-    - [Delete all backups using storage plugin older than timestamp](#delete-all-backups-using-storage-plugin-older-than-timestamp-1)
+    - [Delete information about deleted backups from history database older than n days](#delete-information-about-deleted-backups-from-history-database-older-than-n-days)
+    - [Delete information about deleted backups from history database older than timestamp](#delete-information-about-deleted-backups-from-history-database-older-than-timestamp)
   - [Using container](#using-container-3)
 - [Migrate history database (`history-migrate`)](#migrate-history-database-history-migrate)
   - [Examples](#examples-4)
@@ -442,19 +442,17 @@ docker run \
   --history-db /data/master/gpseg-1/gpbackup_history.db
 ```
 
-# Clean failed and deleted backups from the history database (`history-clean`)
+# Clean deleted backups from the history database (`history-clean`)
 
 Available options for `history-clean` command and their description:
 
 ```bash
 ./gpbackman history-clean -h
 
-Clean failed and deleted backups from the history database.
+Clean deleted backups from the history database.
 Only the database is being cleaned up.
 
-By default, information is deleted only about failed backups from gpbackup_history.db.
-
-To delete information about deleted backups, use the --deleted option.
+Information is deleted only about deleted backups from gpbackup_history.db. Each backup must be deleted first.
 
 To delete information about backups older than the given timestamp, use the --before-timestamp option. 
 To delete information about backups older than the given number of days, use the --older-than-day option. 
@@ -475,7 +473,6 @@ Usage:
 
 Flags:
       --before-timestamp string   delete information about backups older than the given timestamp
-      --deleted                   delete information about deleted backups
   -h, --help                      help for history-clean
       --older-than-days uint      delete information about backups older than the given number of days
 
@@ -488,20 +485,18 @@ Global Flags:
 ```
 
 ## Examples
-### Delete information about failed and deleted backups from history database older than n days
-Delete information about failed and deleted backups from history database older than 7 days:
+### Delete information about deleted backups from history database older than n days
+Delete information about deleted backups from history database older than 7 days:
 ```bash
 ./gpbackman history-clean \
   --older-than-days 7 \
-  --deleted
 ```
 
-### Delete all backups using storage plugin older than timestamp
-Delete information about failed and deleted backups from history database older than timestamp `20240101100000`:
+### Delete information about deleted backups from history database older than timestamp
+Delete information about deleted backups from history database older than timestamp `20240101100000`:
 ```bash
 ./gpbackman history-clean \
   --before-timestamp 20240101100000 \
-  --deleted
 ```
 
 ## Using container
@@ -517,7 +512,6 @@ docker run \
   gpbackman history-clean \
   --older-than-days 7 \
   --history-db /data/master/gpseg-1/gpbackup_history.db \
-  --deleted
 ```
 
 # Migrate history database (`history-migrate`)

--- a/Makefile
+++ b/Makefile
@@ -111,10 +111,10 @@ define e2e_command
 endef
 
 define run_docker_compose
-	GPBACKMAN_UID=$(UID) GPBACKMAN_GID=$(GID) docker-compose -f e2e_tests/docker-compose.yml build --force-rm --parallel ${1}
-	GPBACKMAN_UID=$(UID) GPBACKMAN_GID=$(GID) docker-compose -f e2e_tests/docker-compose.yml run --rm --name ${1} ${1}
+	GPBACKMAN_UID=$(UID) GPBACKMAN_GID=$(GID) docker compose -f e2e_tests/docker-compose.yml build --force-rm --parallel ${1}
+	GPBACKMAN_UID=$(UID) GPBACKMAN_GID=$(GID) docker compose -f e2e_tests/docker-compose.yml run --rm --name ${1} ${1}
 endef
 
 define down_docker_compose
-	GPBACKMAN_UID=$(UID) GPBACKMAN_GID=$(GID) docker-compose -f e2e_tests/docker-compose.yml down -v
+	GPBACKMAN_UID=$(UID) GPBACKMAN_GID=$(GID) docker compose -f e2e_tests/docker-compose.yml down -v
 endef

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The utility works with both history database formats: `gpbackup_history.yaml` fi
 * display the backup report for existing backups;
 * delete existing backups from local storage or using storage plugins (for example, [S3 Storage Plugin](https://github.com/greenplum-db/gpbackup-s3-plugin));
 * delete all existing backups from local storage or using storage plugins older than the specified time condition;
-* clean failed and deleted backups from the history database;
+* clean deleted backups from the history database;
 * migrate history database from `gpbackup_history.yaml` format to `gpbackup_history.db` SQLite format.
 
 ## Commands
@@ -34,7 +34,7 @@ Available Commands:
   backup-info     Display information about backups
   completion      Generate the autocompletion script for the specified shell
   help            Help about any command
-  history-clean   Clean failed and deleted backups from the history database
+  history-clean   Clean deleted backups from the history database
   history-migrate Migrate history database
   report-info     Display the report for a specific backup
 
@@ -56,7 +56,7 @@ Description of each command:
 * [Delete all existing backups older than the specified time condition (`backup-clean`)](./COMMANDS.md#delete-all-existing-backups-older-than-the-specified-time-condition-backup-clean)
 * [Delete a specific existing backup (`backup-delete`)](./COMMANDS.md#delete-a-specific-existing-backup-backup-delete)
 * [Display information about backups (`backup-info`)](./COMMANDS.md#display-information-about-backups-backup-info)
-* [Clean failed and deleted backups from the history database (`history-clean`)](./COMMANDS.md#clean-failed-and-deleted-backups-from-the-history-database-history-clean)
+* [Clean deleted backups from the history database (`history-clean`)](./COMMANDS.md#clean-deleted-backups-from-the-history-database-history-clean)
 * [Migrate history database (`history-migrate`)](./COMMANDS.md#migrate-history-database-history-migrate)
 * [Display the report for a specific backup (`report-info`)](./COMMANDS.md#display-the-report-for-a-specific-backup-report-info)
 

--- a/cmd/history_clean.go
+++ b/cmd/history_clean.go
@@ -14,7 +14,6 @@ import (
 var (
 	historyCleanBeforeTimestamp string
 	historyCleanOlderThenDays   uint
-	historyCleanDeleted         bool
 )
 
 var historyCleanCmd = &cobra.Command{
@@ -23,9 +22,7 @@ var historyCleanCmd = &cobra.Command{
 	Long: `Clean failed and deleted backups from the history database.
 Only the database is being cleaned up.
 
-By default, information is deleted only about failed backups from gpbackup_history.db.
-
-To delete information about deleted backups, use the --deleted option.
+Information is deleted only about deleted backups from gpbackup_history.db. Each backup must be deleted first.
 
 To delete information about backups older than the given timestamp, use the --before-timestamp option. 
 To delete information about backups older than the given number of days, use the --older-than-day option. 
@@ -62,12 +59,6 @@ func init() {
 		beforeTimestampFlagName,
 		"",
 		"delete information about backups older than the given timestamp",
-	)
-	historyCleanCmd.Flags().BoolVar(
-		&historyCleanDeleted,
-		deletedFlagName,
-		false,
-		"delete information about deleted backups",
 	)
 	historyCleanCmd.MarkFlagsMutuallyExclusive(beforeTimestampFlagName, olderThenDaysFlagName)
 }
@@ -114,7 +105,7 @@ func cleanHistory() error {
 				gplog.Error(textmsg.ErrorTextUnableActionHistoryDB("close", closeErr))
 			}
 		}()
-		err = historyCleanDB(beforeTimestamp, historyCleanDeleted, hDB)
+		err = historyCleanDB(beforeTimestamp, hDB)
 		if err != nil {
 			return err
 		}
@@ -126,7 +117,7 @@ func cleanHistory() error {
 				return err
 			}
 			if len(parseHData.BackupConfigs) != 0 {
-				err = historyCleanFile(beforeTimestamp, historyCleanDeleted, &parseHData)
+				err = historyCleanFile(beforeTimestamp, &parseHData)
 				if err != nil {
 					return err
 				}
@@ -141,15 +132,15 @@ func cleanHistory() error {
 	return nil
 }
 
-func historyCleanDB(cutOffTimestamp string, cleanDeleted bool, hDB *sql.DB) error {
-	backupList, err := gpbckpconfig.GetBackupNamesForCleanBeforeTimestamp(cutOffTimestamp, cleanDeleted, hDB)
+func historyCleanDB(cutOffTimestamp string, hDB *sql.DB) error {
+	backupList, err := gpbckpconfig.GetBackupNamesForCleanBeforeTimestamp(cutOffTimestamp, hDB)
 	if err != nil {
 		gplog.Error(textmsg.ErrorTextUnableReadHistoryDB(err))
 		return err
 	}
 	if len(backupList) > 0 {
 		gplog.Debug(textmsg.InfoTextBackupDeleteListFromHistory(backupList))
-		err := gpbckpconfig.CleanBackupsDB(backupList, sqliteDeleteBatchSize, cleanDeleted, hDB)
+		err := gpbckpconfig.CleanBackupsDB(backupList, sqliteDeleteBatchSize, hDB)
 		if err != nil {
 			return err
 		}
@@ -159,30 +150,20 @@ func historyCleanDB(cutOffTimestamp string, cleanDeleted bool, hDB *sql.DB) erro
 	return nil
 }
 
-func historyCleanFile(cutOffTimestamp string, cleanDeleted bool, parseHData *gpbckpconfig.History) error {
+func historyCleanFile(cutOffTimestamp string, parseHData *gpbckpconfig.History) error {
 	backupIdxs := make([]int, 0)
 	backupList := make([]string, 0)
 	for idx, backupConfig := range parseHData.BackupConfigs {
 		// In history file we have sorted timestamps by descending order.
 		if backupConfig.Timestamp < cutOffTimestamp {
-			backupSuccessStatus, err := backupConfig.IsSuccess()
+			backupDateDeleted, err := backupConfig.GetBackupDateDeleted()
 			if err != nil {
-				gplog.Error(textmsg.ErrorTextUnableGetBackupValue("status", backupConfig.Timestamp, err))
+				gplog.Error(textmsg.ErrorTextUnableGetBackupValue("date deletion", backupConfig.Timestamp, err))
 				return err
 			}
-			if !backupSuccessStatus {
+			if !gpbckpconfig.IsBackupActive(backupDateDeleted) && (backupDateDeleted != gpbckpconfig.DateDeletedInProgress) {
 				backupIdxs = append(backupIdxs, idx)
 				backupList = append(backupList, backupConfig.Timestamp)
-			} else if cleanDeleted {
-				backupDateDeleted, errDateDeleted := backupConfig.GetBackupDateDeleted()
-				if errDateDeleted != nil {
-					gplog.Error(textmsg.ErrorTextUnableGetBackupValue("date deletion", backupConfig.Timestamp, errDateDeleted))
-					return err
-				}
-				if !gpbckpconfig.IsBackupActive(backupDateDeleted) && (backupDateDeleted != gpbckpconfig.DateDeletedInProgress) {
-					backupIdxs = append(backupIdxs, idx)
-					backupList = append(backupList, backupConfig.Timestamp)
-				}
 			}
 		}
 	}

--- a/cmd/history_clean.go
+++ b/cmd/history_clean.go
@@ -18,8 +18,8 @@ var (
 
 var historyCleanCmd = &cobra.Command{
 	Use:   "history-clean",
-	Short: "Clean failed and deleted backups from the history database",
-	Long: `Clean failed and deleted backups from the history database.
+	Short: "Clean deleted backups from the history database",
+	Long: `Clean deleted backups from the history database.
 Only the database is being cleaned up.
 
 Information is deleted only about deleted backups from gpbackup_history.db. Each backup must be deleted first.

--- a/cmd/wrappers_test.go
+++ b/cmd/wrappers_test.go
@@ -211,7 +211,7 @@ func TestCheckBackupCanBeUsed(t *testing.T) {
 				Plugin:      gpbckpconfig.BackupS3Plugin,
 				DateDeleted: "",
 			},
-			want:    false,
+			want:    true,
 			wantErr: false,
 		},
 		{
@@ -223,7 +223,7 @@ func TestCheckBackupCanBeUsed(t *testing.T) {
 				Plugin:      gpbckpconfig.BackupS3Plugin,
 				DateDeleted: "",
 			},
-			want:    false,
+			want:    true,
 			wantErr: false,
 		},
 		{
@@ -283,8 +283,8 @@ func TestCheckBackupCanBeUsed(t *testing.T) {
 				Plugin:      gpbckpconfig.BackupS3Plugin,
 				DateDeleted: "",
 			},
-			want:    false,
-			wantErr: true,
+			want:    true,
+			wantErr: false,
 		},
 		{
 			name:            "Successful backup with plugin with deletion in progress and force",

--- a/e2e_tests/conf/Dockerfile.s3_plugin
+++ b/e2e_tests/conf/Dockerfile.s3_plugin
@@ -14,5 +14,5 @@ RUN apk add --no-cache --update build-base bash perl \
     && cd /tmp/gpbackup-s3-plugin \
     && make build
 
-FROM gpbackman as gpbackman-plugins
+FROM gpbackman AS gpbackman-plugins
 COPY --from=s3_plugin-builder /go/bin/gpbackup_s3_plugin /home/gpbackman/gpbackup_s3_plugin

--- a/e2e_tests/docker-compose.yml
+++ b/e2e_tests/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   ################################################################
   # Prepare infra for some tests.

--- a/e2e_tests/scripts/run_backup-clean.sh
+++ b/e2e_tests/scripts/run_backup-clean.sh
@@ -53,49 +53,6 @@ if [ "${result_cnt_sqlite}" != "${TEST_CNT_SQL}" ]; then
 fi
 echo "[INFO] ${GPBACKMAN_TEST_COMMAND} test ${TEST_ID} passed."
 
-################################################################
-# Test 2.
-# Test cascade delete option.
-# All backupd older than timestamp should be deleted.
-TEST_ID="2"
-
-gpbackman ${GPBACKMAN_TEST_COMMAND} \
---history-file ${WORK_DIR}/gpbackup_history_incremental_plugin.yaml \
---before-timestamp  ${TIMESTAMP} \
---plugin-config ${HOME_DIR}/gpbackup_s3_plugin.yaml \
---cascade
-
-gpbackman ${GPBACKMAN_TEST_COMMAND} \
---history-db ${WORK_DIR}/gpbackup_history.db \
---before-timestamp ${TIMESTAMP} \
---plugin-config ${HOME_DIR}/gpbackup_s3_plugin.yaml \
---cascade
-
-GPBACKMAN_RESULT_YAML=$(gpbackman backup-info \
---history-file ${WORK_DIR}/gpbackup_history_incremental_plugin.yaml \
---deleted)
-
-GPBACKMAN_RESULT_SQLITE=$(gpbackman backup-info \
---history-db ${WORK_DIR}/gpbackup_history.db \
---deleted)
-
-# After successful delete, in history there should be 11 fo sql and 7 for yaml backup with date deleted info.
-TEST_CNT_YAML=7
-TEST_CNT_SQL=17
-
-echo "[INFO] ${GPBACKMAN_TEST_COMMAND} test ${TEST_ID}."
-result_cnt_yaml=$(echo "${GPBACKMAN_RESULT_YAML}" | cut -f9 -d'|' | awk '{$1=$1};1' | grep -E ${DATE_REGEX} | wc -l)
-if [ "${result_cnt_yaml}" != "${TEST_CNT_YAML}" ]; then
-    echo -e "[ERROR] ${GPBACKMAN_TEST_COMMAND} test ${TEST_ID} failed.\nget_yaml=${result_cnt_yaml}, want=${TEST_CNT_YAML}"
-    exit 1
-fi
-
-result_cnt_sqlite=$(echo "${GPBACKMAN_RESULT_SQLITE}" | cut -f9 -d'|' | awk '{$1=$1};1' | grep -E ${DATE_REGEX} | wc -l)
-if [ "${result_cnt_sqlite}" != "${TEST_CNT_SQL}" ]; then
-    echo -e "[ERROR] ${GPBACKMAN_TEST_COMMAND} test ${TEST_ID} failed.\nget_sqlite=${result_cnt_sqlite}, want=${TEST_CNT_SQL}"
-    exit 1
-fi
-echo "[INFO] ${GPBACKMAN_TEST_COMMAND} test ${TEST_ID} passed."
 
 echo "[INFO] ${GPBACKMAN_TEST_COMMAND} all tests passed"
 exit 0

--- a/e2e_tests/scripts/run_history-clean.sh
+++ b/e2e_tests/scripts/run_history-clean.sh
@@ -34,12 +34,10 @@ gpbackman ${GPBACKMAN_TEST_COMMAND} \
 --history-file ${WORK_DIR}/gpbackup_history_failure_plugin.yaml \
 --history-file ${WORK_DIR}/gpbackup_history_incremental_plugin.yaml \
 --before-timestamp  ${TIMESTAMP} \
---deleted
 
 gpbackman ${GPBACKMAN_TEST_COMMAND} \
 --history-db ${WORK_DIR}/gpbackup_history.db \
 --before-timestamp ${TIMESTAMP} \
---deleted
 
 GPBACKMAN_RESULT_YAML=$(gpbackman backup-info \
 --history-file ${WORK_DIR}/gpbackup_history_failure_plugin.yaml \

--- a/gpbckpconfig/struct.go
+++ b/gpbckpconfig/struct.go
@@ -59,8 +59,9 @@ const (
 	BackupTypeDataOnly     = "data-only"
 	BackupTypeMetadataOnly = "metadata-only"
 	// Backup statuses.
-	BackupStatusSuccess = "Success"
-	BackupStatusFailure = "Failure"
+	BackupStatusSuccess    = "Success"
+	BackupStatusFailure    = "Failure"
+	BackupStatusInProgress = "In Progress"
 	// Object filtering types.
 	objectFilteringIncludeSchema = "include-schema"
 	objectFilteringExcludeSchema = "exclude-schema"
@@ -200,14 +201,14 @@ func (backupConfig BackupConfig) GetBackupDateDeleted() (string, error) {
 // IsSuccess Check backup status.
 // Returns:
 //   - true  - if backup is successful,
-//   - false - false if backup is not successful.
+//   - false - false if backup is not successful or in progress.
 //
 // In all other cases, an error is returned.
 func (backupConfig BackupConfig) IsSuccess() (bool, error) {
 	switch backupConfig.Status {
 	case BackupStatusSuccess:
 		return true, nil
-	case BackupStatusFailure:
+	case BackupStatusFailure, BackupStatusInProgress:
 		return false, nil
 	default:
 		return false, errors.New("backup status does not match any of the available values")
@@ -220,6 +221,10 @@ func (backupConfig BackupConfig) IsSuccess() (bool, error) {
 //   - false - if the backup in plugin storage (plugin field is not empty).
 func (backupConfig BackupConfig) IsLocal() bool {
 	return backupConfig.Plugin == ""
+}
+
+func (backupConfig BackupConfig) IsInProgress() bool {
+	return backupConfig.Status == BackupStatusInProgress
 }
 
 // GetReportFilePathPlugin Return path to report file name for specific plugin.

--- a/gpbckpconfig/utils_db_test.go
+++ b/gpbckpconfig/utils_db_test.go
@@ -69,7 +69,7 @@ ORDER BY timestamp DESC;
 SELECT timestamp 
 FROM backups 
 WHERE timestamp < '20240101120000' 
-	AND status != 'Failure' 
+	AND status != 'In Progress' 
 	AND date_deleted IN ('', 'Plugin Backup Delete Failed', 'Local Delete Failed') 
 ORDER BY timestamp DESC;
 `},
@@ -91,22 +91,20 @@ func TestGetBackupNameForCleanBeforeTimestampQuery(t *testing.T) {
 		want  string
 	}{
 		{
-			name:  "Show deleted and failed backups",
+			name:  "Show backups",
 			value: "20240101120000",
 			showD: true,
-			want:  `SELECT timestamp FROM backups WHERE timestamp < '20240101120000' AND (status = 'Failure' OR date_deleted NOT IN ('', 'Plugin Backup Delete Failed', 'Local Delete Failed', 'In progress')) ORDER BY timestamp DESC;`,
-		},
-		{
-			name:  "Show only failed backups",
-			value: "20240101120000",
-			showD: false,
-			want:  `SELECT timestamp FROM backups WHERE timestamp < '20240101120000' AND status = 'Failure' ORDER BY timestamp DESC;`,
-		},
+			want: `
+SELECT timestamp 
+FROM backups 
+WHERE timestamp < '20240101120000' 
+	AND date_deleted NOT IN ('', 'Plugin Backup Delete Failed', 'Local Delete Failed', 'In progress') 
+ORDER BY timestamp DESC;
+`},
 	}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := getBackupNameForCleanBeforeTimestampQuery(tt.value, tt.showD); got != tt.want {
+			if got := getBackupNameForCleanBeforeTimestampQuery(tt.value); got != tt.want {
 				t.Errorf("getBackupNameForCleanBeforeTimestampQuery(%v, %v):\n%v\nwant:\n%v", tt.value, tt.showD, got, tt.want)
 			}
 		})

--- a/textmsg/info.go
+++ b/textmsg/info.go
@@ -10,11 +10,11 @@ func InfoTextBackupDeleteStart(backupName string) string {
 }
 
 func InfoTextBackupAlreadyDeleted(backupName string) string {
-	return fmt.Sprintf("Backup %s has already been deleted.", backupName)
+	return fmt.Sprintf("Backup %s has already been deleted", backupName)
 }
 
-func InfoTextBackupFailedStatus(backupName string) string {
-	return fmt.Sprintf("Backup %s has failed status.", backupName)
+func InfoTextBackupStatus(backupName, backupStatus string) string {
+	return fmt.Sprintf("Backup %s has status: %s", backupName, backupStatus)
 }
 
 func InfoTextBackupDeleteSuccess(backupName string) string {

--- a/textmsg/info_test.go
+++ b/textmsg/info_test.go
@@ -25,13 +25,7 @@ func TestInfoTextFunctionAndArg(t *testing.T) {
 			name:     "Test InfoTextBackupAlreadyDeleted",
 			value:    "TestBackup",
 			function: InfoTextBackupAlreadyDeleted,
-			want:     "Backup TestBackup has already been deleted.",
-		},
-		{
-			name:     "Test InfoTextBackupUnableDeleteFailed",
-			value:    "TestBackup",
-			function: InfoTextBackupFailedStatus,
-			want:     "Backup TestBackup has failed status.",
+			want:     "Backup TestBackup has already been deleted",
 		},
 		{
 			name:     "Test InfoTextBackupDirPath",
@@ -49,6 +43,31 @@ func TestInfoTextFunctionAndArg(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := tt.function(tt.value); got != tt.want {
+				t.Errorf("\nVariables do not match:\n%s\nwant:\n%s", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestInfoTextFunctionAndTwoArgs(t *testing.T) {
+	tests := []struct {
+		name     string
+		value1   string
+		value2   string
+		function func(string, string) string
+		want     string
+	}{
+		{
+			name:     "Test InfoTextBackupUnableDeleteFailed",
+			value1:   "TestBackup",
+			value2:   "In Progress",
+			function: InfoTextBackupStatus,
+			want:     "Backup TestBackup has status: In Progress",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.function(tt.value1, tt.value2); got != tt.want {
 				t.Errorf("\nVariables do not match:\n%s\nwant:\n%s", got, tt.want)
 			}
 		})


### PR DESCRIPTION
gpbackup  save information in `$MASTER_DATA_DIRECTORY/backups`. It is necessary to clear backup information on the master.

Added deletion of files on the master when deleting a backup using a plugin. Also, performed a small refactoring with the addition of handlers for error handling. 

There may be cases when a backup hangs in the `In Progress` status. Additionally, backups in the `Failure` status save information about themselves. You can get a report for them, and they also need to be deleted.

The conditions in `checkBackupCanBeUsed()` function have been changed to work with backups that have not been deleted. This allows for the deletion of backups in `Failure` or `In Progress` statuses.

The `--deleted` flag was removed for `history-clean` command.
Only deleted backups are deleted. In order to delete information about backup from the database, it must have the deleted status.

The tests have been updated for these changes.