### PR TITLE
Switch to go 1.23.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Install goveralls
         run: |
-          GO111MODULE=off go get -u github.com/mattn/goveralls
+          go install github.com/mattn/goveralls@latest
 
       - name: Submit coverage
         run: $(go env GOPATH)/bin/goveralls -service="github" -coverprofile=$GITHUB_WORKSPACE/coverage.out

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,12 +14,12 @@ jobs:
       app_name: "gpbackman"
     steps:
       - name: Set up go 1.23
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: "1.23"
         id: go
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Build and test
         run: |
@@ -29,9 +29,9 @@ jobs:
           TZ: "Etc/UTC"
 
       - name: Run linters
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.56.2
+          version: v1.62.2
         env:
           TZ: "Etc/UTC"
 
@@ -45,11 +45,11 @@ jobs:
           COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Available platforms
         run: echo ${{ steps.buildx.outputs.platforms }}
@@ -110,24 +110,31 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     env: 
-      goreleaser_version: "v1.24.0"
+      goreleaser_version: "v2.5.0"
     steps:
       - name: Set up go 1.23
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: "1.23"
         id: go
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Get ref
         id: vars
         run: |
           echo ::set-output name=ref::$(echo ${GITHUB_REF} | cut -d'/' -f3)
 
+      - name: Check GoReleaser config
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: ${{ env.goreleaser_version }}
+          args: check .goreleaser.yml
+
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v4
+        uses: goreleaser/goreleaser-action@v6
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
         with:
           distribution: goreleaser

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,10 +13,10 @@ jobs:
       build_platforms: "linux/amd64,linux/arm64"
       app_name: "gpbackman"
     steps:
-      - name: Set up go 1.21
+      - name: Set up go 1.23
         uses: actions/setup-go@v3
         with:
-          go-version: "1.21"
+          go-version: "1.23"
         id: go
       - name: Checkout
         uses: actions/checkout@v3
@@ -112,10 +112,10 @@ jobs:
     env: 
       goreleaser_version: "v1.24.0"
     steps:
-      - name: Set up go 1.21
+      - name: Set up go 1.23
         uses: actions/setup-go@v3
         with:
-          go-version: "1.21"
+          go-version: "1.23"
         id: go
 
       - name: Checkout

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,18 +2,13 @@ run:
   timeout: 5m
   output:
     format: colored-line-number
-  skip-dirs:
-    - vendor
 
 linters-settings:
   govet:
-    check-shadowing: true
+    enable:
+      - shadow
   revive:
     confidence: 0.1
-  golint:
-    min-confidence: 0.1
-  maligned:
-    suggest-new: true
   goconst:
     min-len: 2
     min-occurrences: 2
@@ -38,12 +33,10 @@ linters-settings:
 
 linters:
   enable:
-    - megacheck
+    - staticcheck
     - revive
     - govet
     - unconvert
-    - megacheck
-    - gas
     - gocyclo
     - dupl
     - misspell
@@ -53,15 +46,16 @@ linters:
     - ineffassign
     - stylecheck
     # - gochecknoinits
-    - exportloopref
+    - copyloopvar
     - gocritic
     - nakedret
     - gosimple
-    - prealloc
   fast: false
   disable-all: true
 
 issues:
+  exclude-dirs:
+    - vendor
   exclude-rules:
     - text: "at least one file in a package should have a package comment"
       linters:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -60,6 +60,9 @@ issues:
     - text: "at least one file in a package should have a package comment"
       linters:
         - stylecheck
+    - text: "non-constant format string"
+      linters:
+        - govet
     - path: _test\.go
       linters:
         - gosec

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,4 +1,6 @@
 ---
+version: 2
+
 project_name: gpbackman
 
 builds:
@@ -21,7 +23,6 @@ archives:
     format: tar.gz
     name_template: '{{ .Binary }}-{{ .Version }}-{{ if eq .Os "darwin" }}macos{{ else }}{{ .Os }}{{ end }}-{{ if eq .Arch "amd64" }}x86_64{{ else }}{{ .Arch }}{{ end }}'
     wrap_in_directory: true
-    rlcp: true
 
 nfpms:
   - id: gpbackman
@@ -54,4 +55,4 @@ release:
   draft: true
 
 changelog:
-  skip: true
+  disable: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG REPO_BUILD_TAG="unknown"
 
-FROM golang:1.21-alpine3.19 AS builder
+FROM golang:1.23-alpine3.19 AS builder
 ARG REPO_BUILD_TAG
 COPY . /build
 WORKDIR /build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG REPO_BUILD_TAG="unknown"
 
-FROM golang:1.23-alpine3.19 AS builder
+FROM golang:1.23-alpine3.20 AS builder
 ARG REPO_BUILD_TAG
 COPY . /build
 WORKDIR /build
@@ -10,7 +10,7 @@ RUN apk add --no-cache --update build-base \
         -ldflags "-X main.version=${REPO_BUILD_TAG}" \
         -o gpbackman gpbackman.go
 
-FROM alpine:3.19
+FROM alpine:3.20
 ARG REPO_BUILD_TAG
 ENV TZ="Etc/UTC" \
     GPBACKMAN_USER="gpbackman" \

--- a/Dockerfile.artifacts
+++ b/Dockerfile.artifacts
@@ -1,7 +1,7 @@
-FROM --platform=linux/amd64 goreleaser/goreleaser:v1.24.0 as builder
+FROM --platform=linux/amd64 goreleaser/goreleaser:v2.5.0 as builder
 WORKDIR /build
 COPY . /build
-RUN goreleaser release --snapshot --skip-publish --clean
+RUN goreleaser release --snapshot --skip=publish --clean
 
 FROM alpine:3.20
 COPY --from=builder /build/dist/ /dist/

--- a/Dockerfile.artifacts
+++ b/Dockerfile.artifacts
@@ -3,7 +3,7 @@ WORKDIR /build
 COPY . /build
 RUN goreleaser release --snapshot --skip-publish --clean
 
-FROM alpine:3.19
+FROM alpine:3.20
 COPY --from=builder /build/dist/ /dist/
 RUN mkdir -p /artifacts && \
     cp /dist/*.tar.gz /artifacts/ && \

--- a/e2e_tests/conf/Dockerfile.s3_plugin
+++ b/e2e_tests/conf/Dockerfile.s3_plugin
@@ -4,7 +4,7 @@ ARG S3_PLUGIN_VERSION="1.10.1"
 # to the archive on GitHub. At the same time, all tags have been deleted from the archives.
 # The fork containing the necessary tags is used for testing.
 
-FROM golang:1.21-alpine3.19 AS s3_plugin-builder
+FROM golang:1.23-alpine3.19 AS s3_plugin-builder
 ARG S3_PLUGIN_VERSION
 RUN apk add --no-cache --update build-base bash perl \
     # && wget https://github.com/greenplum-db/gpbackup-s3-plugin/archive/refs/tags/${S3_PLUGIN_VERSION}.tar.gz -O /tmp/gpbackup-s3-plugin-${S3_PLUGIN_VERSION}.tar.gz \

--- a/e2e_tests/conf/Dockerfile.s3_plugin
+++ b/e2e_tests/conf/Dockerfile.s3_plugin
@@ -4,7 +4,7 @@ ARG S3_PLUGIN_VERSION="1.10.1"
 # to the archive on GitHub. At the same time, all tags have been deleted from the archives.
 # The fork containing the necessary tags is used for testing.
 
-FROM golang:1.23-alpine3.19 AS s3_plugin-builder
+FROM golang:1.23-alpine3.20 AS s3_plugin-builder
 ARG S3_PLUGIN_VERSION
 RUN apk add --no-cache --update build-base bash perl \
     # && wget https://github.com/greenplum-db/gpbackup-s3-plugin/archive/refs/tags/${S3_PLUGIN_VERSION}.tar.gz -O /tmp/gpbackup-s3-plugin-${S3_PLUGIN_VERSION}.tar.gz \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/woblerr/gpbackman
 
-go 1.21
+go 1.23
 
 require (
 	github.com/greenplum-db/gp-common-go-libs v1.0.15


### PR DESCRIPTION
* Switch to go `1.23`.
* Switch to alpine `3.20`.
* Bump goreleaser to `v2.5.0`.
* Bump golangci-lint  to `v1.62.2`, fix linters.
* Bump actions/setup-go to `v5`.
* Bump actions/checkout to `v4`.
* Bump golangci/golangci-lint-action to `v6`.
* Bump docker/setup-qemu-action to `v3`.
* Bump docker/setup-buildx-action to `v3`.
* Bump goreleaser/goreleaser-action to `v6`.