### PR TITLE
Bump go and dependencies versions.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,10 +13,10 @@ jobs:
       build_platforms: "linux/amd64,linux/arm64"
       app_name: "gpbackman"
     steps:
-      - name: Set up go 1.23
+      - name: Set up go 1.24
         uses: actions/setup-go@v5
         with:
-          go-version: "1.23"
+          go-version: "1.24"
         id: go
       - name: Checkout
         uses: actions/checkout@v4
@@ -112,10 +112,10 @@ jobs:
     env: 
       goreleaser_version: "v2.5.0"
     steps:
-      - name: Set up go 1.23
+      - name: Set up go 1.24
         uses: actions/setup-go@v5
         with:
-          go-version: "1.23"
+          go-version: "1.24"
         id: go
 
       - name: Checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,9 +29,9 @@ jobs:
           TZ: "Etc/UTC"
 
       - name: Run linters
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
-          version: v1.62.2
+          version: v2.3.1
         env:
           TZ: "Etc/UTC"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,7 +110,7 @@ jobs:
     needs: build
     runs-on: ubuntu-22.04
     env: 
-      goreleaser_version: "v2.5.0"
+      goreleaser_version: "v2.11.2"
     steps:
       - name: Set up go 1.24
         uses: actions/setup-go@v5

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,72 +1,68 @@
-run:
-  timeout: 5m
-
-output:
-  formats:
-    - format: colored-line-number
-
-linters-settings:
-  govet:
-    enable:
-      - shadow
-  revive:
-    confidence: 0.1
-  goconst:
-    min-len: 2
-    min-occurrences: 2
-  misspell:
-    locale: US
-  lll:
-    line-length: 140
-  gocyclo:
-    min-complexity: 25
-  gocritic:
-    enabled-tags:
-      - performance
-      - style
-      - experimental
-    disabled-checks:
-      - filepathJoin
-      - hugeParam
-      - rangeValCopy
-      - octalLiteral
-      - unnamedResult
-      - todoCommentWithoutDetail
+version: "2"
 
 linters:
+  default: none
   enable:
-    - staticcheck
-    - revive
-    - govet
-    - unconvert
-    - gocyclo
     - dupl
+    - gochecknoinits
+    - gocritic
+    - gocyclo
+    - gosec
+    - govet
+    - ineffassign
     - misspell
+    - nakedret
+    - prealloc
+    - revive
+    - staticcheck
+    - unconvert
     - unparam
     - unused
-    - typecheck
-    - ineffassign
-    - stylecheck
-    # - gochecknoinits
-    - copyloopvar
-    - gocritic
-    - nakedret
-    - gosimple
-  fast: false
-  disable-all: true
+  settings:
+    goconst:
+      min-len: 2
+      min-occurrences: 2
+    gocritic:
+      enabled-tags:
+        - performance
+        - style
+        - experimental
+      disabled-checks:
+        - hugeParam
+        - rangeValCopy
+        - unnamedResult
+        - filepathJoin
+    govet:
+      enable:
+        - shadow
+    revive:
+      confidence: 0.1
+    misspell:
+      locale: US
+    lll:
+      line-length: 140
+  exclusions:
+    generated: lax
+    rules:
+      - linters:
+          - gochecknoinits
+        text: don't use `init` function
+      - linters:
+          - staticcheck
+        text: at least one file in a package should have a package comment
+      - linters:
+          - revive
+        text: should have a package comment
+      - linters:
+          - gosec
+        text: integer overflow conversion uint -> int
+      - linters:
+          - gosec
+        path: _test\.go
+    paths:
+      - vendor
 
-issues:
-  exclude-dirs:
-    - vendor
-  exclude-rules:
-    - text: "at least one file in a package should have a package comment"
-      linters:
-        - stylecheck
-    - text: "non-constant format string"
-      linters:
-        - govet
-    - path: _test\.go
-      linters:
-        - gosec
-        - dupl
-  exclude-use-default: false
+run:
+  timeout: 5m
+  modules-download-mode: vendor
+  relative-path-mode: gomod

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -4,7 +4,8 @@ version: 2
 project_name: gpbackman
 
 builds:
-  - env: 
+  - id: gpbackman
+    env:
       - CGO_ENABLED=1
     goos: 
       - linux
@@ -20,14 +21,14 @@ archives:
   - id: gpbackman
     files:
       - LICENSE
-    format: tar.gz
+    formats: [tar.gz]
     name_template: '{{ .Binary }}-{{ .Version }}-{{ if eq .Os "darwin" }}macos{{ else }}{{ .Os }}{{ end }}-{{ if eq .Arch "amd64" }}x86_64{{ else }}{{ .Arch }}{{ end }}'
     wrap_in_directory: true
 
 nfpms:
   - id: gpbackman
     package_name: gpbackman
-    builds:
+    ids:
       - gpbackman
     homepage: https://github.com/woblerr/gpbackman
     maintainer: Anton Kurochkin

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG REPO_BUILD_TAG="unknown"
 
-FROM golang:1.23-alpine3.20 AS builder
+FROM golang:1.24-alpine3.20 AS builder
 ARG REPO_BUILD_TAG
 COPY . /build
 WORKDIR /build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG REPO_BUILD_TAG="unknown"
 
-FROM golang:1.24-alpine3.20 AS builder
+FROM golang:1.24-alpine3.21 AS builder
 ARG REPO_BUILD_TAG
 COPY . /build
 WORKDIR /build
@@ -10,7 +10,7 @@ RUN apk add --no-cache --update build-base \
         -ldflags "-X main.version=${REPO_BUILD_TAG}" \
         -o gpbackman gpbackman.go
 
-FROM alpine:3.20
+FROM alpine:3.21
 ARG REPO_BUILD_TAG
 ENV TZ="Etc/UTC" \
     GPBACKMAN_USER="gpbackman" \

--- a/Dockerfile.artifacts
+++ b/Dockerfile.artifacts
@@ -3,7 +3,7 @@ WORKDIR /build
 COPY . /build
 RUN goreleaser release --snapshot --skip=publish --clean
 
-FROM alpine:3.20
+FROM alpine:3.21
 COPY --from=builder /build/dist/ /dist/
 RUN mkdir -p /artifacts && \
     cp /dist/*.tar.gz /artifacts/ && \

--- a/Dockerfile.artifacts
+++ b/Dockerfile.artifacts
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 goreleaser/goreleaser:v2.5.0 as builder
+FROM --platform=linux/amd64 goreleaser/goreleaser:v2.11.2 as builder
 WORKDIR /build
 COPY . /build
 RUN goreleaser release --snapshot --skip=publish --clean

--- a/cmd/backup_clean.go
+++ b/cmd/backup_clean.go
@@ -120,7 +120,7 @@ func doCleanBackupFlagValidation(flags *pflag.FlagSet) {
 	if flags.Changed(beforeTimestampFlagName) {
 		err = gpbckpconfig.CheckTimestamp(backupCleanBeforeTimestamp)
 		if err != nil {
-			gplog.Error(textmsg.ErrorTextUnableValidateFlag(backupCleanBeforeTimestamp, beforeTimestampFlagName, err))
+			gplog.Error("%s", textmsg.ErrorTextUnableValidateFlag(backupCleanBeforeTimestamp, beforeTimestampFlagName, err))
 			execOSExit(exitErrorCode)
 		}
 		beforeTimestamp = backupCleanBeforeTimestamp
@@ -132,7 +132,7 @@ func doCleanBackupFlagValidation(flags *pflag.FlagSet) {
 	if flags.Changed(afterTimestampFlagName) {
 		err = gpbckpconfig.CheckTimestamp(backupCleanAfterTimestamp)
 		if err != nil {
-			gplog.Error(textmsg.ErrorTextUnableValidateFlag(backupCleanAfterTimestamp, afterTimestampFlagName, err))
+			gplog.Error("%s", textmsg.ErrorTextUnableValidateFlag(backupCleanAfterTimestamp, afterTimestampFlagName, err))
 			execOSExit(exitErrorCode)
 		}
 		afterTimestamp = backupCleanAfterTimestamp
@@ -140,25 +140,25 @@ func doCleanBackupFlagValidation(flags *pflag.FlagSet) {
 	// backup-dir anf plugin-config flags cannot be used together.
 	err = checkCompatibleFlags(flags, backupDirFlagName, pluginConfigFileFlagName)
 	if err != nil {
-		gplog.Error(textmsg.ErrorTextUnableCompatibleFlags(err, backupDirFlagName, pluginConfigFileFlagName))
+		gplog.Error("%s", textmsg.ErrorTextUnableCompatibleFlags(err, backupDirFlagName, pluginConfigFileFlagName))
 		execOSExit(exitErrorCode)
 	}
 	// If parallel-processes flag is specified and have correct values.
 	if flags.Changed(parallelProcessesFlagName) && !gpbckpconfig.IsPositiveValue(backupCleanParallelProcesses) {
-		gplog.Error(textmsg.ErrorTextUnableValidateFlag(strconv.Itoa(backupCleanParallelProcesses), parallelProcessesFlagName, err))
+		gplog.Error("%s", textmsg.ErrorTextUnableValidateFlag(strconv.Itoa(backupCleanParallelProcesses), parallelProcessesFlagName, err))
 		execOSExit(exitErrorCode)
 	}
 	// plugin-config and parallel-precesses flags cannot be used together.
 	err = checkCompatibleFlags(flags, parallelProcessesFlagName, pluginConfigFileFlagName)
 	if err != nil {
-		gplog.Error(textmsg.ErrorTextUnableCompatibleFlags(err, parallelProcessesFlagName, pluginConfigFileFlagName))
+		gplog.Error("%s", textmsg.ErrorTextUnableCompatibleFlags(err, parallelProcessesFlagName, pluginConfigFileFlagName))
 		execOSExit(exitErrorCode)
 	}
 	// If backup-dir flag is specified and it exists and the full path is specified.
 	if flags.Changed(backupDirFlagName) {
 		err = gpbckpconfig.CheckFullPath(backupCleanBackupDir, checkFileExistsConst)
 		if err != nil {
-			gplog.Error(textmsg.ErrorTextUnableValidateFlag(backupCleanBackupDir, backupDirFlagName, err))
+			gplog.Error("%s", textmsg.ErrorTextUnableValidateFlag(backupCleanBackupDir, backupDirFlagName, err))
 			execOSExit(exitErrorCode)
 		}
 	}
@@ -166,12 +166,12 @@ func doCleanBackupFlagValidation(flags *pflag.FlagSet) {
 	if flags.Changed(pluginConfigFileFlagName) {
 		err = gpbckpconfig.CheckFullPath(backupCleanPluginConfigFile, checkFileExistsConst)
 		if err != nil {
-			gplog.Error(textmsg.ErrorTextUnableValidateFlag(backupCleanPluginConfigFile, pluginConfigFileFlagName, err))
+			gplog.Error("%s", textmsg.ErrorTextUnableValidateFlag(backupCleanPluginConfigFile, pluginConfigFileFlagName, err))
 			execOSExit(exitErrorCode)
 		}
 	}
 	if beforeTimestamp == "" && afterTimestamp == "" {
-		gplog.Error(textmsg.ErrorTextUnableValidateValue(textmsg.ErrorValidationValue(), olderThenDaysFlagName, beforeTimestampFlagName, afterTimestampFlagName))
+		gplog.Error("%s", textmsg.ErrorTextUnableValidateValue(textmsg.ErrorValidationValue(), olderThenDaysFlagName, beforeTimestampFlagName, afterTimestampFlagName))
 		execOSExit(exitErrorCode)
 	}
 }
@@ -187,19 +187,19 @@ func doCleanBackup() {
 func cleanBackup() error {
 	hDB, err := gpbckpconfig.OpenHistoryDB(getHistoryDBPath(rootHistoryDB))
 	if err != nil {
-		gplog.Error(textmsg.ErrorTextUnableActionHistoryDB("open", err))
+		gplog.Error("%s", textmsg.ErrorTextUnableActionHistoryDB("open", err))
 		return err
 	}
 	defer func() {
 		closeErr := hDB.Close()
 		if closeErr != nil {
-			gplog.Error(textmsg.ErrorTextUnableActionHistoryDB("close", closeErr))
+			gplog.Error("%s", textmsg.ErrorTextUnableActionHistoryDB("close", closeErr))
 		}
 	}()
 	if backupCleanPluginConfigFile != "" {
 		pluginConfig, err := utils.ReadPluginConfig(backupCleanPluginConfigFile)
 		if err != nil {
-			gplog.Error(textmsg.ErrorTextUnableReadPluginConfigFile(err))
+			gplog.Error("%s", textmsg.ErrorTextUnableReadPluginConfigFile(err))
 			return err
 		}
 		err = backupCleanDBPlugin(backupCleanCascade, beforeTimestamp, afterTimestamp, backupCleanPluginConfigFile, pluginConfig, hDB)
@@ -218,11 +218,11 @@ func cleanBackup() error {
 func backupCleanDBPlugin(deleteCascade bool, cutOffTimestamp, cutOffAfterTimestamp, pluginConfigPath string, pluginConfig *utils.PluginConfig, hDB *sql.DB) error {
 	backupList, err := fetchBackupNamesForDeletion(cutOffTimestamp, cutOffAfterTimestamp, hDB)
 	if err != nil {
-		gplog.Error(textmsg.ErrorTextUnableReadHistoryDB(err))
+		gplog.Error("%s", textmsg.ErrorTextUnableReadHistoryDB(err))
 		return err
 	}
 	if len(backupList) > 0 {
-		gplog.Debug(textmsg.InfoTextBackupDeleteList(backupList))
+		gplog.Debug("%s", textmsg.InfoTextBackupDeleteList(backupList))
 		// Execute deletion for each backup.
 		// Use backupDeleteDBPlugin function from backup-delete command.
 		// Don't use force deletes and ignore errors for mass deletion.
@@ -231,7 +231,7 @@ func backupCleanDBPlugin(deleteCascade bool, cutOffTimestamp, cutOffAfterTimesta
 			return err
 		}
 	} else {
-		gplog.Info(textmsg.InfoTextNothingToDo())
+		gplog.Info("%s", textmsg.InfoTextNothingToDo())
 	}
 	return nil
 }
@@ -239,17 +239,17 @@ func backupCleanDBPlugin(deleteCascade bool, cutOffTimestamp, cutOffAfterTimesta
 func backupCleanDBLocal(deleteCascade bool, cutOffTimestamp, cutOffAfterTimestamp, backupDir string, maxParallelProcesses int, hDB *sql.DB) error {
 	backupList, err := fetchBackupNamesForDeletion(cutOffTimestamp, cutOffAfterTimestamp, hDB)
 	if err != nil {
-		gplog.Error(textmsg.ErrorTextUnableReadHistoryDB(err))
+		gplog.Error("%s", textmsg.ErrorTextUnableReadHistoryDB(err))
 		return err
 	}
 	if len(backupList) > 0 {
-		gplog.Debug(textmsg.InfoTextBackupDeleteList(backupList))
+		gplog.Debug("%s", textmsg.InfoTextBackupDeleteList(backupList))
 		err = backupDeleteDBLocal(backupList, backupDir, deleteCascade, false, false, maxParallelProcesses, hDB)
 		if err != nil {
 			return err
 		}
 	} else {
-		gplog.Info(textmsg.InfoTextNothingToDo())
+		gplog.Info("%s", textmsg.InfoTextNothingToDo())
 	}
 	return nil
 }

--- a/cmd/backup_delete.go
+++ b/cmd/backup_delete.go
@@ -132,7 +132,7 @@ func doDeleteBackupFlagValidation(flags *pflag.FlagSet) {
 		for _, timestamp := range backupDeleteTimestamp {
 			err = gpbckpconfig.CheckTimestamp(timestamp)
 			if err != nil {
-				gplog.Error(textmsg.ErrorTextUnableValidateFlag(timestamp, timestampFlagName, err))
+				gplog.Error("%s", textmsg.ErrorTextUnableValidateFlag(timestamp, timestampFlagName, err))
 				execOSExit(exitErrorCode)
 			}
 		}
@@ -140,25 +140,25 @@ func doDeleteBackupFlagValidation(flags *pflag.FlagSet) {
 	// backup-dir anf plugin-config flags cannot be used together.
 	err = checkCompatibleFlags(flags, backupDirFlagName, pluginConfigFileFlagName)
 	if err != nil {
-		gplog.Error(textmsg.ErrorTextUnableCompatibleFlags(err, backupDirFlagName, pluginConfigFileFlagName))
+		gplog.Error("%s", textmsg.ErrorTextUnableCompatibleFlags(err, backupDirFlagName, pluginConfigFileFlagName))
 		execOSExit(exitErrorCode)
 	}
 	// If parallel-processes flag is specified and have correct values.
 	if flags.Changed(parallelProcessesFlagName) && !gpbckpconfig.IsPositiveValue(backupDeleteParallelProcesses) {
-		gplog.Error(textmsg.ErrorTextUnableValidateFlag(strconv.Itoa(backupDeleteParallelProcesses), parallelProcessesFlagName, err))
+		gplog.Error("%s", textmsg.ErrorTextUnableValidateFlag(strconv.Itoa(backupDeleteParallelProcesses), parallelProcessesFlagName, err))
 		execOSExit(exitErrorCode)
 	}
 	// plugin-config and parallel-precesses flags cannot be used together.
 	err = checkCompatibleFlags(flags, parallelProcessesFlagName, pluginConfigFileFlagName)
 	if err != nil {
-		gplog.Error(textmsg.ErrorTextUnableCompatibleFlags(err, parallelProcessesFlagName, pluginConfigFileFlagName))
+		gplog.Error("%s", textmsg.ErrorTextUnableCompatibleFlags(err, parallelProcessesFlagName, pluginConfigFileFlagName))
 		execOSExit(exitErrorCode)
 	}
 	// If backup-dir flag is specified and it exists and the full path is specified.
 	if flags.Changed(backupDirFlagName) {
 		err = gpbckpconfig.CheckFullPath(backupDeleteBackupDir, checkFileExistsConst)
 		if err != nil {
-			gplog.Error(textmsg.ErrorTextUnableValidateFlag(backupDeleteBackupDir, backupDirFlagName, err))
+			gplog.Error("%s", textmsg.ErrorTextUnableValidateFlag(backupDeleteBackupDir, backupDirFlagName, err))
 			execOSExit(exitErrorCode)
 		}
 	}
@@ -166,13 +166,13 @@ func doDeleteBackupFlagValidation(flags *pflag.FlagSet) {
 	if flags.Changed(pluginConfigFileFlagName) {
 		err = gpbckpconfig.CheckFullPath(backupDeletePluginConfigFile, checkFileExistsConst)
 		if err != nil {
-			gplog.Error(textmsg.ErrorTextUnableValidateFlag(backupDeletePluginConfigFile, pluginConfigFileFlagName, err))
+			gplog.Error("%s", textmsg.ErrorTextUnableValidateFlag(backupDeletePluginConfigFile, pluginConfigFileFlagName, err))
 			execOSExit(exitErrorCode)
 		}
 	}
 	// If ignore-errors flag is specified, but force flag is not.
 	if flags.Changed(ignoreErrorsFlagName) && !flags.Changed(forceFlagName) {
-		gplog.Error(textmsg.ErrorTextUnableValidateValue(textmsg.ErrorNotIndependentFlagsError(), ignoreErrorsFlagName, forceFlagName))
+		gplog.Error("%s", textmsg.ErrorTextUnableValidateValue(textmsg.ErrorNotIndependentFlagsError(), ignoreErrorsFlagName, forceFlagName))
 		execOSExit(exitErrorCode)
 	}
 
@@ -189,13 +189,13 @@ func doDeleteBackup() {
 func deleteBackup() error {
 	hDB, err := gpbckpconfig.OpenHistoryDB(getHistoryDBPath(rootHistoryDB))
 	if err != nil {
-		gplog.Error(textmsg.ErrorTextUnableActionHistoryDB("open", err))
+		gplog.Error("%s", textmsg.ErrorTextUnableActionHistoryDB("open", err))
 		return err
 	}
 	defer func() {
 		closeErr := hDB.Close()
 		if closeErr != nil {
-			gplog.Error(textmsg.ErrorTextUnableActionHistoryDB("close", closeErr))
+			gplog.Error("%s", textmsg.ErrorTextUnableActionHistoryDB("close", closeErr))
 		}
 	}()
 	if backupDeletePluginConfigFile != "" {
@@ -238,7 +238,7 @@ func backupDeleteDB(backupListForDeletion []string, deleteCascade, deleteForce, 
 	for _, backupName := range backupListForDeletion {
 		backupData, err := gpbckpconfig.GetBackupDataDB(backupName, hDB)
 		if err != nil {
-			gplog.Error(textmsg.ErrorTextUnableGetBackupInfo(backupName, err))
+			gplog.Error("%s", textmsg.ErrorTextUnableGetBackupInfo(backupName, err))
 			return err
 		}
 		canBeDeleted, err := checkBackupCanBeUsed(deleteForce, skipLocalBackup, backupData)
@@ -248,21 +248,21 @@ func backupDeleteDB(backupListForDeletion []string, deleteCascade, deleteForce, 
 		if canBeDeleted {
 			backupDependencies, err := gpbckpconfig.GetBackupDependencies(backupName, hDB)
 			if err != nil {
-				gplog.Error(textmsg.ErrorTextUnableGetBackupValue("dependencies", backupName, err))
+				gplog.Error("%s", textmsg.ErrorTextUnableGetBackupValue("dependencies", backupName, err))
 				return err
 			}
 			if len(backupDependencies) > 0 {
-				gplog.Info(textmsg.InfoTextBackupDependenciesList(backupName, backupDependencies))
+				gplog.Info("%s", textmsg.InfoTextBackupDependenciesList(backupName, backupDependencies))
 				if deleteCascade {
-					gplog.Debug(textmsg.InfoTextBackupDeleteList(backupDependencies))
+					gplog.Debug("%s", textmsg.InfoTextBackupDeleteList(backupDependencies))
 					// If the deletion of at least one dependent backup fails, we fail full entire chain.
 					err = backupDeleteDBCascade(backupDependencies, deleteForce, ignoreErrors, skipLocalBackup, deleter, hDB)
 					if err != nil {
-						gplog.Error(textmsg.ErrorTextUnableDeleteBackupCascade(backupName, err))
+						gplog.Error("%s", textmsg.ErrorTextUnableDeleteBackupCascade(backupName, err))
 						return err
 					}
 				} else {
-					gplog.Error(textmsg.ErrorTextUnableDeleteBackupUseCascade(backupName, textmsg.ErrorBackupDeleteCascadeOptionError()))
+					gplog.Error("%s", textmsg.ErrorTextUnableDeleteBackupUseCascade(backupName, textmsg.ErrorBackupDeleteCascadeOptionError()))
 					return textmsg.ErrorBackupDeleteCascadeOptionError()
 				}
 			}
@@ -279,7 +279,7 @@ func backupDeleteDBCascade(backupList []string, deleteForce, ignoreErrors, skipL
 	for _, backup := range backupList {
 		backupData, err := gpbckpconfig.GetBackupDataDB(backup, hDB)
 		if err != nil {
-			gplog.Error(textmsg.ErrorTextUnableGetBackupInfo(backup, err))
+			gplog.Error("%s", textmsg.ErrorTextUnableGetBackupInfo(backup, err))
 			return err
 		}
 		// Skip local backup.
@@ -300,16 +300,16 @@ func backupDeleteDBCascade(backupList []string, deleteForce, ignoreErrors, skipL
 func backupDeleteDBPluginFunc(backupName, pluginConfigPath string, pluginConfig *utils.PluginConfig, hDB *sql.DB, ignoreErrors bool) error {
 	var err error
 	dateDeleted := getCurrentTimestamp()
-	gplog.Info(textmsg.InfoTextBackupDeleteStart(backupName))
+	gplog.Info("%s", textmsg.InfoTextBackupDeleteStart(backupName))
 	err = gpbckpconfig.UpdateDeleteStatus(backupName, gpbckpconfig.DateDeletedInProgress, hDB)
 	if err != nil {
-		gplog.Error(textmsg.ErrorTextUnableSetBackupStatus(gpbckpconfig.DateDeletedInProgress, backupName, err))
+		gplog.Error("%s", textmsg.ErrorTextUnableSetBackupStatus(gpbckpconfig.DateDeletedInProgress, backupName, err))
 		return err
 	}
-	gplog.Debug(textmsg.InfoTextCommandExecution(pluginConfig.ExecutablePath, deleteBackupPluginCommand, pluginConfigPath, backupName))
+	gplog.Debug("%s", textmsg.InfoTextCommandExecution(pluginConfig.ExecutablePath, deleteBackupPluginCommand, pluginConfigPath, backupName))
 	stdout, stderr, errdel := execDeleteBackupPlugin(pluginConfig.ExecutablePath, deleteBackupPluginCommand, pluginConfigPath, backupName)
 	if stderr != "" {
-		gplog.Error(stderr)
+		gplog.Error("%s", stderr)
 	}
 	if errdel != nil {
 		handleErrorDB(backupName, textmsg.ErrorTextUnableDeleteBackup(backupName, errdel), gpbckpconfig.DateDeletedPluginFailed, hDB)
@@ -317,7 +317,7 @@ func backupDeleteDBPluginFunc(backupName, pluginConfigPath string, pluginConfig 
 			return errdel
 		}
 	}
-	gplog.Info(stdout)
+	gplog.Info("%s", stdout)
 	backupData, err := gpbckpconfig.GetBackupDataDB(backupName, hDB)
 	if err != nil {
 		handleErrorDB(backupName, textmsg.ErrorTextUnableGetBackupInfo(backupName, err), gpbckpconfig.DateDeletedPluginFailed, hDB)
@@ -332,7 +332,7 @@ func backupDeleteDBPluginFunc(backupName, pluginConfigPath string, pluginConfig 
 			return err
 		}
 	}
-	gplog.Debug(textmsg.InfoTextCommandExecution("delete directory", gpbckpconfig.BackupDirPath(bckpDir, backupName)))
+	gplog.Debug("%s", textmsg.InfoTextCommandExecution("delete directory", gpbckpconfig.BackupDirPath(bckpDir, backupName)))
 	// Delete local files on master.
 	err = os.RemoveAll(gpbckpconfig.BackupDirPath(bckpDir, backupName))
 	if err != nil {
@@ -343,20 +343,20 @@ func backupDeleteDBPluginFunc(backupName, pluginConfigPath string, pluginConfig 
 	}
 	err = gpbckpconfig.UpdateDeleteStatus(backupName, dateDeleted, hDB)
 	if err != nil {
-		gplog.Error(textmsg.ErrorTextUnableSetBackupStatus(dateDeleted, backupName, err))
+		gplog.Error("%s", textmsg.ErrorTextUnableSetBackupStatus(dateDeleted, backupName, err))
 		return err
 	}
-	gplog.Info(textmsg.InfoTextBackupDeleteSuccess(backupName))
+	gplog.Info("%s", textmsg.InfoTextBackupDeleteSuccess(backupName))
 	return nil
 }
 
 func backupDeleteDBLocalFunc(backupName, backupDir string, maxParallelProcesses int, hDB *sql.DB, ignoreErrors bool) error {
 	var err, errUpdate error
 	dateDeleted := getCurrentTimestamp()
-	gplog.Info(textmsg.InfoTextBackupDeleteStart(backupName))
+	gplog.Info("%s", textmsg.InfoTextBackupDeleteStart(backupName))
 	errUpdate = gpbckpconfig.UpdateDeleteStatus(backupName, gpbckpconfig.DateDeletedInProgress, hDB)
 	if errUpdate != nil {
-		gplog.Error(textmsg.ErrorTextUnableSetBackupStatus(gpbckpconfig.DateDeletedInProgress, backupName, errUpdate))
+		gplog.Error("%s", textmsg.ErrorTextUnableSetBackupStatus(gpbckpconfig.DateDeletedInProgress, backupName, errUpdate))
 		return errUpdate
 	}
 	backupData, err := gpbckpconfig.GetBackupDataDB(backupName, hDB)
@@ -369,8 +369,8 @@ func backupDeleteDBLocalFunc(backupName, backupDir string, maxParallelProcesses 
 		handleErrorDB(backupName, textmsg.ErrorTextUnableGetBackupPath("backup directory", backupName, err), gpbckpconfig.DateDeletedLocalFailed, hDB)
 		return err
 	}
-	gplog.Debug(textmsg.InfoTextBackupDirPath(bckpDir))
-	gplog.Debug(textmsg.InfoTextSegmentPrefix(segPrefix))
+	gplog.Debug("%s", textmsg.InfoTextBackupDirPath(bckpDir))
+	gplog.Debug("%s", textmsg.InfoTextSegmentPrefix(segPrefix))
 	backupType, err := backupData.GetBackupType()
 	if err != nil {
 		handleErrorDB(backupName, textmsg.ErrorTextUnableGetBackupValue("type", backupName, err), gpbckpconfig.DateDeletedLocalFailed, hDB)
@@ -397,7 +397,7 @@ func backupDeleteDBLocalFunc(backupName, backupDir string, maxParallelProcesses 
 		}
 	}
 	// Delete files on master.
-	gplog.Debug(textmsg.InfoTextCommandExecution("delete directory", gpbckpconfig.BackupDirPath(bckpDir, backupName)))
+	gplog.Debug("%s", textmsg.InfoTextCommandExecution("delete directory", gpbckpconfig.BackupDirPath(bckpDir, backupName)))
 	err = os.RemoveAll(gpbckpconfig.BackupDirPath(bckpDir, backupName))
 	if err != nil {
 		handleErrorDB(backupName, textmsg.ErrorTextUnableDeleteBackup(backupName, err), gpbckpconfig.DateDeletedLocalFailed, hDB)
@@ -407,10 +407,10 @@ func backupDeleteDBLocalFunc(backupName, backupDir string, maxParallelProcesses 
 	}
 	errUpdate = gpbckpconfig.UpdateDeleteStatus(backupName, dateDeleted, hDB)
 	if errUpdate != nil {
-		gplog.Error(textmsg.ErrorTextUnableSetBackupStatus(dateDeleted, backupName, errUpdate))
+		gplog.Error("%s", textmsg.ErrorTextUnableSetBackupStatus(dateDeleted, backupName, errUpdate))
 		return errUpdate
 	}
-	gplog.Info(textmsg.InfoTextBackupDeleteSuccess(backupName))
+	gplog.Info("%s", textmsg.InfoTextBackupDeleteSuccess(backupName))
 	return nil
 }
 
@@ -511,13 +511,13 @@ func checkBackupDirExistsOnSegments(path, host string, sshConf *ssh.ClientConfig
 	}
 	defer session.Close()
 	command := fmt.Sprintf("test -d %s", path)
-	gplog.Debug(textmsg.InfoTextCommandExecution(command, "on host", host))
+	gplog.Debug("%s", textmsg.InfoTextCommandExecution(command, "on host", host))
 	if err := session.Run(command); err != nil {
-		gplog.Error(textmsg.ErrorTextCommandExecutionFailed(err, command, "on host", host))
+		gplog.Error("%s", textmsg.ErrorTextCommandExecutionFailed(err, command, "on host", host))
 		errCh <- textmsg.ErrorNotFoundBackupDirIn(fmt.Sprintf("%s on host %s", path, host))
 		return
 	}
-	gplog.Debug(textmsg.InfoTextCommandExecutionSucceeded(command, "on host", host))
+	gplog.Debug("%s", textmsg.InfoTextCommandExecutionSucceeded(command, "on host", host))
 }
 
 func deleteBackupDirOnSegments(path, host string, sshConf *ssh.ClientConfig, errCh chan error) {
@@ -535,13 +535,13 @@ func deleteBackupDirOnSegments(path, host string, sshConf *ssh.ClientConfig, err
 	}
 	defer session.Close()
 	command := fmt.Sprintf("rm -rf %s", path)
-	gplog.Debug(textmsg.InfoTextCommandExecution(command, "on host", host))
+	gplog.Debug("%s", textmsg.InfoTextCommandExecution(command, "on host", host))
 	if err := session.Run(command); err != nil {
-		gplog.Error(textmsg.ErrorTextCommandExecutionFailed(err, command, "on host", host))
+		gplog.Error("%s", textmsg.ErrorTextCommandExecutionFailed(err, command, "on host", host))
 		errCh <- err
 		return
 	}
-	gplog.Debug(textmsg.InfoTextCommandExecutionSucceeded(command, "on host", host))
+	gplog.Debug("%s", textmsg.InfoTextCommandExecutionSucceeded(command, "on host", host))
 }
 
 func getSSHConfig() (*ssh.ClientConfig, error) {

--- a/cmd/backup_info.go
+++ b/cmd/backup_info.go
@@ -124,7 +124,7 @@ func doBackupInfoFlagValidation(flags *pflag.FlagSet) {
 		}
 	}
 	// If exclude flag is specified, but table or schema flag is not.
-	if flags.Changed(excludeFlagName) && !(flags.Changed(tableFlagName) || flags.Changed(schemaFlagName)) {
+	if flags.Changed(excludeFlagName) && !flags.Changed(tableFlagName) && !flags.Changed(schemaFlagName) {
 		gplog.Error(textmsg.ErrorTextUnableValidateValue(textmsg.ErrorNotIndependentFlagsError(), tableFlagName, schemaFlagName))
 		execOSExit(exitErrorCode)
 	}

--- a/cmd/backup_info.go
+++ b/cmd/backup_info.go
@@ -105,27 +105,27 @@ func doBackupInfoFlagValidation(flags *pflag.FlagSet) {
 	if flags.Changed(typeFlagName) {
 		err = checkBackupType(backupInfoBackupTypeFilter)
 		if err != nil {
-			gplog.Error(textmsg.ErrorTextUnableValidateFlag(backupInfoBackupTypeFilter, typeFlagName, err))
+			gplog.Error("%s", textmsg.ErrorTextUnableValidateFlag(backupInfoBackupTypeFilter, typeFlagName, err))
 			execOSExit(exitErrorCode)
 		}
 	}
 	// table flag and schema flags cannot be used together.
 	err = checkCompatibleFlags(flags, tableFlagName, schemaFlagName)
 	if err != nil {
-		gplog.Error(textmsg.ErrorTextUnableCompatibleFlags(err, tableFlagName, schemaFlagName))
+		gplog.Error("%s", textmsg.ErrorTextUnableCompatibleFlags(err, tableFlagName, schemaFlagName))
 		execOSExit(exitErrorCode)
 	}
 	// If table is specified and have correct values.
 	if flags.Changed(tableFlagName) {
 		err = gpbckpconfig.CheckTableFQN(backupInfoTableNameFilter)
 		if err != nil {
-			gplog.Error(textmsg.ErrorTextUnableValidateFlag(backupInfoTableNameFilter, tableFlagName, err))
+			gplog.Error("%s", textmsg.ErrorTextUnableValidateFlag(backupInfoTableNameFilter, tableFlagName, err))
 			execOSExit(exitErrorCode)
 		}
 	}
 	// If exclude flag is specified, but table or schema flag is not.
 	if flags.Changed(excludeFlagName) && !flags.Changed(tableFlagName) && !flags.Changed(schemaFlagName) {
-		gplog.Error(textmsg.ErrorTextUnableValidateValue(textmsg.ErrorNotIndependentFlagsError(), tableFlagName, schemaFlagName))
+		gplog.Error("%s", textmsg.ErrorTextUnableValidateValue(textmsg.ErrorNotIndependentFlagsError(), tableFlagName, schemaFlagName))
 		execOSExit(exitErrorCode)
 	}
 }
@@ -143,13 +143,13 @@ func backupInfo() error {
 	initTable(t)
 	hDB, err := gpbckpconfig.OpenHistoryDB(getHistoryDBPath(rootHistoryDB))
 	if err != nil {
-		gplog.Error(textmsg.ErrorTextUnableActionHistoryDB("open", err))
+		gplog.Error("%s", textmsg.ErrorTextUnableActionHistoryDB("open", err))
 		return err
 	}
 	defer func() {
 		closeErr := hDB.Close()
 		if closeErr != nil {
-			gplog.Error(textmsg.ErrorTextUnableActionHistoryDB("close", closeErr))
+			gplog.Error("%s", textmsg.ErrorTextUnableActionHistoryDB("close", closeErr))
 		}
 	}()
 	err = backupInfoDB(
@@ -171,13 +171,13 @@ func backupInfo() error {
 func backupInfoDB(showDeleted, showFailed, backupExcludeFilter bool, backupTypeFilter, backupTableFilter, backupSchemaFilter string, hDB *sql.DB, t table.Writer) error {
 	backupList, err := gpbckpconfig.GetBackupNamesDB(showDeleted, showFailed, hDB)
 	if err != nil {
-		gplog.Error(textmsg.ErrorTextUnableReadHistoryDB(err))
+		gplog.Error("%s", textmsg.ErrorTextUnableReadHistoryDB(err))
 		return err
 	}
 	for _, backupName := range backupList {
 		backupData, err := gpbckpconfig.GetBackupDataDB(backupName, hDB)
 		if err != nil {
-			gplog.Error(textmsg.ErrorTextUnableGetBackupInfo(backupName, err))
+			gplog.Error("%s", textmsg.ErrorTextUnableGetBackupInfo(backupName, err))
 			return err
 		}
 		addBackupToTable(backupTypeFilter, backupTableFilter, backupSchemaFilter, backupExcludeFilter, backupData, t)
@@ -212,23 +212,23 @@ func addBackupToTable(backupTypeFilter, backupTableFilter, backupSchemaFilter st
 	var matchToObjectFilter bool
 	backupDate, err := backupData.GetBackupDate()
 	if err != nil {
-		gplog.Error(textmsg.ErrorTextUnableGetBackupValue("date", backupData.Timestamp, err))
+		gplog.Error("%s", textmsg.ErrorTextUnableGetBackupValue("date", backupData.Timestamp, err))
 	}
 	backupType, err := backupData.GetBackupType()
 	if err != nil {
-		gplog.Error(textmsg.ErrorTextUnableGetBackupValue("type", backupData.Timestamp, err))
+		gplog.Error("%s", textmsg.ErrorTextUnableGetBackupValue("type", backupData.Timestamp, err))
 	}
 	backupFilter, err := backupData.GetObjectFilteringInfo()
 	if err != nil {
-		gplog.Error(textmsg.ErrorTextUnableGetBackupValue("object filtering", backupData.Timestamp, err))
+		gplog.Error("%s", textmsg.ErrorTextUnableGetBackupValue("object filtering", backupData.Timestamp, err))
 	}
 	backupDuration, err := backupData.GetBackupDuration()
 	if err != nil {
-		gplog.Error(textmsg.ErrorTextUnableGetBackupValue("duration", backupData.Timestamp, err))
+		gplog.Error("%s", textmsg.ErrorTextUnableGetBackupValue("duration", backupData.Timestamp, err))
 	}
 	backupDateDeleted, err := backupData.GetBackupDateDeleted()
 	if err != nil {
-		gplog.Error(textmsg.ErrorTextUnableGetBackupValue("date deletion", backupData.Timestamp, err))
+		gplog.Error("%s", textmsg.ErrorTextUnableGetBackupValue("date deletion", backupData.Timestamp, err))
 	}
 	matchToObjectFilter = backupData.CheckObjectFilteringExists(backupTableFilter, backupSchemaFilter, backupFilter, backupExcludeFilter)
 	if (backupTypeFilter == "" || backupTypeFilter == backupType) && matchToObjectFilter {

--- a/cmd/history_clean.go
+++ b/cmd/history_clean.go
@@ -63,7 +63,7 @@ func doCleanHistoryFlagValidation(flags *pflag.FlagSet) {
 	if flags.Changed(beforeTimestampFlagName) {
 		err = gpbckpconfig.CheckTimestamp(historyCleanBeforeTimestamp)
 		if err != nil {
-			gplog.Error(textmsg.ErrorTextUnableValidateFlag(historyCleanBeforeTimestamp, beforeTimestampFlagName, err))
+			gplog.Error("%s", textmsg.ErrorTextUnableValidateFlag(historyCleanBeforeTimestamp, beforeTimestampFlagName, err))
 			execOSExit(exitErrorCode)
 		}
 		beforeTimestamp = historyCleanBeforeTimestamp
@@ -72,7 +72,7 @@ func doCleanHistoryFlagValidation(flags *pflag.FlagSet) {
 		beforeTimestamp = gpbckpconfig.GetTimestampOlderThen(historyCleanOlderThenDays)
 	}
 	if beforeTimestamp == "" {
-		gplog.Error(textmsg.ErrorTextUnableValidateValue(textmsg.ErrorValidationValue(), olderThenDaysFlagName, beforeTimestampFlagName))
+		gplog.Error("%s", textmsg.ErrorTextUnableValidateValue(textmsg.ErrorValidationValue(), olderThenDaysFlagName, beforeTimestampFlagName))
 		execOSExit(exitErrorCode)
 	}
 }
@@ -88,13 +88,13 @@ func doCleanHistory() {
 func cleanHistory() error {
 	hDB, err := gpbckpconfig.OpenHistoryDB(getHistoryDBPath(rootHistoryDB))
 	if err != nil {
-		gplog.Error(textmsg.ErrorTextUnableActionHistoryDB("open", err))
+		gplog.Error("%s", textmsg.ErrorTextUnableActionHistoryDB("open", err))
 		return err
 	}
 	defer func() {
 		closeErr := hDB.Close()
 		if closeErr != nil {
-			gplog.Error(textmsg.ErrorTextUnableActionHistoryDB("close", closeErr))
+			gplog.Error("%s", textmsg.ErrorTextUnableActionHistoryDB("close", closeErr))
 		}
 	}()
 	err = historyCleanDB(beforeTimestamp, hDB)
@@ -107,17 +107,17 @@ func cleanHistory() error {
 func historyCleanDB(cutOffTimestamp string, hDB *sql.DB) error {
 	backupList, err := gpbckpconfig.GetBackupNamesForCleanBeforeTimestamp(cutOffTimestamp, hDB)
 	if err != nil {
-		gplog.Error(textmsg.ErrorTextUnableReadHistoryDB(err))
+		gplog.Error("%s", textmsg.ErrorTextUnableReadHistoryDB(err))
 		return err
 	}
 	if len(backupList) > 0 {
-		gplog.Debug(textmsg.InfoTextBackupDeleteListFromHistory(backupList))
+		gplog.Debug("%s", textmsg.InfoTextBackupDeleteListFromHistory(backupList))
 		err := gpbckpconfig.CleanBackupsDB(backupList, sqliteDeleteBatchSize, hDB)
 		if err != nil {
 			return err
 		}
 	} else {
-		gplog.Info(textmsg.InfoTextNothingToDo())
+		gplog.Info("%s", textmsg.InfoTextNothingToDo())
 	}
 	return nil
 }

--- a/cmd/history_migrate.go
+++ b/cmd/history_migrate.go
@@ -57,7 +57,7 @@ func doHistoryMigrateFlagValidation(flags *pflag.FlagSet) {
 			// Always check the existence of the file.
 			err = gpbckpconfig.CheckFullPath(hFile, checkFileExistsConst)
 			if err != nil {
-				gplog.Error(textmsg.ErrorTextUnableValidateFlag(hFile, historyFilesFlagName, err))
+				gplog.Error("%s", textmsg.ErrorTextUnableValidateFlag(hFile, historyFilesFlagName, err))
 				execOSExit(exitErrorCode)
 			}
 		}
@@ -75,42 +75,42 @@ func doMigrateHistory() {
 func migrateHistory() error {
 	hDB, err := history.InitializeHistoryDatabase(getHistoryDBPath(rootHistoryDB))
 	if err != nil {
-		gplog.Error(textmsg.ErrorTextUnableInitHistoryDB(err))
+		gplog.Error("%s", textmsg.ErrorTextUnableInitHistoryDB(err))
 		return err
 	}
 	defer func() {
 		closeErr := hDB.Close()
 		if closeErr != nil {
-			gplog.Error(textmsg.ErrorTextUnableActionHistoryDB("close", closeErr))
+			gplog.Error("%s", textmsg.ErrorTextUnableActionHistoryDB("close", closeErr))
 		}
 	}()
 	for _, historyFile := range historyMigrateHistoryFiles {
-		gplog.Info(textmsg.InfoTextMigrateHistoryFile("Start", historyFile))
+		gplog.Info("%s", textmsg.InfoTextMigrateHistoryFile("Start", historyFile))
 		hFile := getHistoryFilePath(historyFile)
 		historyData, err := gpbckpconfig.ReadHistoryFile(hFile)
 		if err != nil {
-			gplog.Error(textmsg.ErrorTextUnableActionHistoryFile("read", err))
+			gplog.Error("%s", textmsg.ErrorTextUnableActionHistoryFile("read", err))
 			return err
 		}
 		parseHData, err := gpbckpconfig.ParseResult(historyData)
 		if err != nil {
-			gplog.Error(textmsg.ErrorTextUnableActionHistoryFile("parse", err))
+			gplog.Error("%s", textmsg.ErrorTextUnableActionHistoryFile("parse", err))
 			return err
 		}
 		for _, backupConfig := range parseHData.BackupConfigs {
 			hBackupConfig := gpbckpconfig.ConvertToHistoryBackupConfig(backupConfig)
 			err = history.StoreBackupHistory(hDB, &hBackupConfig)
 			if err != nil {
-				gplog.Error(textmsg.ErrorTextUnableWriteIntoHistoryDB(err))
+				gplog.Error("%s", textmsg.ErrorTextUnableWriteIntoHistoryDB(err))
 				return err
 			}
 		}
 		err = renameHistoryFile(hFile)
 		if err != nil {
-			gplog.Error(textmsg.ErrorTextUnableActionHistoryFile("rename", err))
+			gplog.Error("%s", textmsg.ErrorTextUnableActionHistoryFile("rename", err))
 			return err
 		}
-		gplog.Info(textmsg.InfoTextMigrateHistoryFile("Finish", historyFile))
+		gplog.Info("%s", textmsg.InfoTextMigrateHistoryFile("Finish", historyFile))
 	}
 	return nil
 }

--- a/cmd/report_info.go
+++ b/cmd/report_info.go
@@ -102,21 +102,21 @@ func doReportInfoFlagValidation(flags *pflag.FlagSet) {
 	if flags.Changed(timestampFlagName) {
 		err = gpbckpconfig.CheckTimestamp(reportInfoTimestamp)
 		if err != nil {
-			gplog.Error(textmsg.ErrorTextUnableValidateFlag(reportInfoTimestamp, timestampFlagName, err))
+			gplog.Error("%s", textmsg.ErrorTextUnableValidateFlag(reportInfoTimestamp, timestampFlagName, err))
 			execOSExit(exitErrorCode)
 		}
 	}
 	// backup-dir anf plugin-config flags cannot be used together.
 	err = checkCompatibleFlags(flags, backupDirFlagName, pluginConfigFileFlagName)
 	if err != nil {
-		gplog.Error(textmsg.ErrorTextUnableCompatibleFlags(err, backupDirFlagName, pluginConfigFileFlagName))
+		gplog.Error("%s", textmsg.ErrorTextUnableCompatibleFlags(err, backupDirFlagName, pluginConfigFileFlagName))
 		execOSExit(exitErrorCode)
 	}
 	// If backup-dir flag is specified and it exists and the full path is specified.
 	if flags.Changed(backupDirFlagName) {
 		err = gpbckpconfig.CheckFullPath(reportInfoBackupDir, checkFileExistsConst)
 		if err != nil {
-			gplog.Error(textmsg.ErrorTextUnableValidateFlag(reportInfoBackupDir, backupDirFlagName, err))
+			gplog.Error("%s", textmsg.ErrorTextUnableValidateFlag(reportInfoBackupDir, backupDirFlagName, err))
 			execOSExit(exitErrorCode)
 		}
 	}
@@ -124,7 +124,7 @@ func doReportInfoFlagValidation(flags *pflag.FlagSet) {
 	if flags.Changed(pluginConfigFileFlagName) {
 		err = gpbckpconfig.CheckFullPath(reportInfoPluginConfigFile, checkFileExistsConst)
 		if err != nil {
-			gplog.Error(textmsg.ErrorTextUnableValidateFlag(reportInfoPluginConfigFile, pluginConfigFileFlagName, err))
+			gplog.Error("%s", textmsg.ErrorTextUnableValidateFlag(reportInfoPluginConfigFile, pluginConfigFileFlagName, err))
 			execOSExit(exitErrorCode)
 		}
 	}
@@ -132,13 +132,13 @@ func doReportInfoFlagValidation(flags *pflag.FlagSet) {
 	if flags.Changed(reportFilePluginPathFlagName) {
 		// But plugin-config flag is not specified.
 		if !flags.Changed(pluginConfigFileFlagName) {
-			gplog.Error(textmsg.ErrorTextUnableValidateValue(textmsg.ErrorNotIndependentFlagsError(), reportFilePluginPathFlagName, pluginConfigFileFlagName))
+			gplog.Error("%s", textmsg.ErrorTextUnableValidateValue(textmsg.ErrorNotIndependentFlagsError(), reportFilePluginPathFlagName, pluginConfigFileFlagName))
 			execOSExit(exitErrorCode)
 		}
 		// Check full path.
 		err = gpbckpconfig.CheckFullPath(reportInfoReportFilePluginPath, false)
 		if err != nil {
-			gplog.Error(textmsg.ErrorTextUnableValidateFlag(reportInfoReportFilePluginPath, reportFilePluginPathFlagName, err))
+			gplog.Error("%s", textmsg.ErrorTextUnableValidateFlag(reportInfoReportFilePluginPath, reportFilePluginPathFlagName, err))
 			execOSExit(exitErrorCode)
 		}
 	}
@@ -155,19 +155,19 @@ func doReportInfo() {
 func reportInfo() error {
 	hDB, err := gpbckpconfig.OpenHistoryDB(getHistoryDBPath(rootHistoryDB))
 	if err != nil {
-		gplog.Error(textmsg.ErrorTextUnableActionHistoryDB("open", err))
+		gplog.Error("%s", textmsg.ErrorTextUnableActionHistoryDB("open", err))
 		return err
 	}
 	defer func() {
 		closeErr := hDB.Close()
 		if closeErr != nil {
-			gplog.Error(textmsg.ErrorTextUnableActionHistoryDB("close", closeErr))
+			gplog.Error("%s", textmsg.ErrorTextUnableActionHistoryDB("close", closeErr))
 		}
 	}()
 	if reportInfoPluginConfigFile != "" {
 		pluginConfig, err := utils.ReadPluginConfig(reportInfoPluginConfigFile)
 		if err != nil {
-			gplog.Error(textmsg.ErrorTextUnableReadPluginConfigFile(err))
+			gplog.Error("%s", textmsg.ErrorTextUnableReadPluginConfigFile(err))
 			return err
 		}
 		err = reportInfoDBPlugin(reportInfoTimestamp, reportInfoPluginConfigFile, pluginConfig, hDB)
@@ -186,7 +186,7 @@ func reportInfo() error {
 func reportInfoDBPlugin(backupName, pluginConfigPath string, pluginConfig *utils.PluginConfig, hDB *sql.DB) error {
 	backupData, err := gpbckpconfig.GetBackupDataDB(backupName, hDB)
 	if err != nil {
-		gplog.Error(textmsg.ErrorTextUnableGetBackupInfo(backupName, err))
+		gplog.Error("%s", textmsg.ErrorTextUnableGetBackupInfo(backupName, err))
 		return err
 	}
 	err = reportInfoPluginFunc(backupData, pluginConfigPath, pluginConfig)
@@ -205,16 +205,16 @@ func reportInfoPluginFunc(backupData gpbckpconfig.BackupConfig, pluginConfigPath
 	if canGetReport {
 		reportFile, err := backupData.GetReportFilePathPlugin(reportInfoReportFilePluginPath, pluginConfig.Options)
 		if err != nil {
-			gplog.Error(textmsg.ErrorTextUnableGetBackupPath("report", backupData.Timestamp, err))
+			gplog.Error("%s", textmsg.ErrorTextUnableGetBackupPath("report", backupData.Timestamp, err))
 			return err
 		}
-		gplog.Debug(textmsg.InfoTextCommandExecution(pluginConfig.ExecutablePath, restoreDataPluginCommand, pluginConfigPath, reportFile))
+			gplog.Debug("%s", textmsg.InfoTextCommandExecution(pluginConfig.ExecutablePath, restoreDataPluginCommand, pluginConfigPath, reportFile))
 		stdout, stderr, err := execReportInfo(pluginConfig.ExecutablePath, restoreDataPluginCommand, pluginConfigPath, reportFile)
 		if stderr != "" {
-			gplog.Error(stderr)
+			gplog.Error("%s", stderr)
 		}
 		if err != nil {
-			gplog.Error(textmsg.ErrorTextUnableGetBackupReport(backupData.Timestamp, err))
+			gplog.Error("%s", textmsg.ErrorTextUnableGetBackupReport(backupData.Timestamp, err))
 			return err
 		}
 		// Display the report.
@@ -226,7 +226,7 @@ func reportInfoPluginFunc(backupData gpbckpconfig.BackupConfig, pluginConfigPath
 func reportInfoDBLocal(backupName, backupDir string, hDB *sql.DB) error {
 	backupData, err := gpbckpconfig.GetBackupDataDB(backupName, hDB)
 	if err != nil {
-		gplog.Error(textmsg.ErrorTextUnableGetBackupInfo(backupName, err))
+		gplog.Error("%s", textmsg.ErrorTextUnableGetBackupInfo(backupName, err))
 		return err
 	}
 	err = reportInfoFileLocalFunc(backupData, backupDir)
@@ -246,18 +246,18 @@ func reportInfoFileLocalFunc(backupData gpbckpconfig.BackupConfig, backupDir str
 		timestamp := backupData.Timestamp
 		bckpDir, segPrefix, _, err := getBackupMasterDir(backupDir, backupData.BackupDir, backupData.DatabaseName)
 		if err != nil {
-			gplog.Error(textmsg.ErrorTextUnableGetBackupPath("backup directory", timestamp, err))
+			gplog.Error("%s", textmsg.ErrorTextUnableGetBackupPath("backup directory", timestamp, err))
 			return err
 		}
-		gplog.Debug(textmsg.InfoTextBackupDirPath(bckpDir))
-		gplog.Debug(textmsg.InfoTextSegmentPrefix(segPrefix))
+		gplog.Debug("%s", textmsg.InfoTextBackupDirPath(bckpDir))
+		gplog.Debug("%s", textmsg.InfoTextSegmentPrefix(segPrefix))
 		reportFile := gpbckpconfig.ReportFilePath(bckpDir, timestamp)
 		// Sanitize the file path
 		reportFile = filepath.Clean(reportFile)
-		gplog.Debug(textmsg.InfoTextCommandExecution("read file", reportFile))
+		gplog.Debug("%s", textmsg.InfoTextCommandExecution("read file", reportFile))
 		content, err := os.ReadFile(reportFile)
 		if err != nil {
-			gplog.Error(textmsg.ErrorTextUnableGetBackupReport(backupData.Timestamp, err))
+			gplog.Error("%s", textmsg.ErrorTextUnableGetBackupReport(backupData.Timestamp, err))
 			return err
 		}
 		fmt.Println(string(content))

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -74,19 +74,19 @@ func doRootFlagValidation(flags *pflag.FlagSet, checkFileExists bool) {
 	if flags.Changed(historyDBFlagName) {
 		err = gpbckpconfig.CheckFullPath(rootHistoryDB, checkFileExists)
 		if err != nil {
-			gplog.Error(textmsg.ErrorTextUnableValidateFlag(rootHistoryDB, historyDBFlagName, err))
+			gplog.Error("%s", textmsg.ErrorTextUnableValidateFlag(rootHistoryDB, historyDBFlagName, err))
 			execOSExit(exitErrorCode)
 		}
 	}
 	// Check, that the log level is correct.
 	err = setLogLevelConsole(rootLogLevelConsole)
 	if err != nil {
-		gplog.Error(textmsg.ErrorTextUnableValidateFlag(rootLogLevelConsole, logLevelConsoleFlagName, err))
+		gplog.Error("%s", textmsg.ErrorTextUnableValidateFlag(rootLogLevelConsole, logLevelConsoleFlagName, err))
 		execOSExit(exitErrorCode)
 	}
 	err = setLogLevelFile(rootLogLevelFile)
 	if err != nil {
-		gplog.Error(textmsg.ErrorTextUnableValidateFlag(rootLogLevelFile, logLevelFileFlagName, err))
+		gplog.Error("%s", textmsg.ErrorTextUnableValidateFlag(rootLogLevelFile, logLevelFileFlagName, err))
 		execOSExit(exitErrorCode)
 	}
 }

--- a/cmd/wrappers.go
+++ b/cmd/wrappers.go
@@ -124,16 +124,16 @@ func checkBackupCanBeUsed(deleteForce, skipLocalBackup bool, backupData gpbckpco
 	result := false
 	err := checkLocalBackupStatus(skipLocalBackup, backupData.IsLocal())
 	if err != nil {
-		gplog.Error(textmsg.ErrorTextUnableWorkBackup(backupData.Timestamp, err))
+		gplog.Error("%s", textmsg.ErrorTextUnableWorkBackup(backupData.Timestamp, err))
 		return result, err
 	}
 	if backupData.IsInProgress() && !deleteForce {
-		gplog.Error(textmsg.InfoTextBackupStatus(backupData.Timestamp, backupData.Status))
+		gplog.Error("%s", textmsg.InfoTextBackupStatus(backupData.Timestamp, backupData.Status))
 		return result, nil
 	}
 	backupDateDeleted, errDateDeleted := backupData.GetBackupDateDeleted()
 	if errDateDeleted != nil {
-		gplog.Error(textmsg.ErrorTextUnableGetBackupValue("date deletion", backupData.Timestamp, errDateDeleted))
+		gplog.Error("%s", textmsg.ErrorTextUnableGetBackupValue("date deletion", backupData.Timestamp, errDateDeleted))
 	}
 	// If the backup date deletion has invalid value, try to delete the backup.
 	if gpbckpconfig.IsBackupActive(backupDateDeleted) || errDateDeleted != nil {
@@ -143,9 +143,9 @@ func checkBackupCanBeUsed(deleteForce, skipLocalBackup bool, backupData gpbckpco
 			// We do not return the error here,
 			// because it is necessary to leave the possibility of starting the process
 			// of deleting backups that are stuck in the "In Progress" status using the --force flag.
-			gplog.Error(textmsg.ErrorTextBackupDeleteInProgress(backupData.Timestamp, textmsg.ErrorBackupDeleteInProgressError()))
+			gplog.Error("%s", textmsg.ErrorTextBackupDeleteInProgress(backupData.Timestamp, textmsg.ErrorBackupDeleteInProgressError()))
 		} else {
-			gplog.Debug(textmsg.InfoTextBackupAlreadyDeleted(backupData.Timestamp))
+			gplog.Debug("%s", textmsg.InfoTextBackupAlreadyDeleted(backupData.Timestamp))
 		}
 	}
 	// If flag --force is set.
@@ -222,14 +222,14 @@ func checkSingleBackupDir(backupDir, segPrefix, segID string, isSingleBackupDir 
 func getBackupMasterDirClusterInfo(dbName string) string {
 	db, err := gpbckpconfig.NewClusterLocalClusterConn(dbName)
 	if err != nil {
-		gplog.Error(textmsg.ErrorTextUnableConnectLocalCluster(err))
+		gplog.Error("%s", textmsg.ErrorTextUnableConnectLocalCluster(err))
 		return ""
 	}
 	defer db.Close()
 	sqlQuery := "SELECT datadir FROM gp_segment_configuration WHERE content = -1 AND role = 'p';"
 	queryResult, err := gpbckpconfig.ExecuteQueryLocalClusterConn[string](db, sqlQuery)
 	if err != nil {
-		gplog.Error(textmsg.ErrorTextUnableGetBackupDirLocalClusterConn(err))
+		gplog.Error("%s", textmsg.ErrorTextUnableGetBackupDirLocalClusterConn(err))
 		return ""
 	}
 	gplog.Debug("Master data directory: %s", queryResult)
@@ -240,23 +240,23 @@ func getSegmentConfigurationClusterInfo(dbName string) ([]gpbckpconfig.SegmentCo
 	queryResult := make([]gpbckpconfig.SegmentConfig, 0)
 	db, err := gpbckpconfig.NewClusterLocalClusterConn(dbName)
 	if err != nil {
-		gplog.Error(textmsg.ErrorTextUnableConnectLocalCluster(err))
+		gplog.Error("%s", textmsg.ErrorTextUnableConnectLocalCluster(err))
 		return queryResult, err
 	}
 	defer db.Close()
 	sqlQuery := "SELECT content as contentid, hostname, datadir FROM gp_segment_configuration WHERE role = 'p' and content != -1 ORDER BY content;"
 	queryResult, err = gpbckpconfig.ExecuteQueryLocalClusterConn[[]gpbckpconfig.SegmentConfig](db, sqlQuery)
 	if err != nil {
-		gplog.Error(textmsg.ErrorTextUnableGetBackupDirLocalClusterConn(err))
+		gplog.Error("%s", textmsg.ErrorTextUnableGetBackupDirLocalClusterConn(err))
 		return queryResult, err
 	}
 	return queryResult, nil
 }
 
 func handleErrorDB(backupName, errorMessage, backupStatus string, hDB *sql.DB) {
-	gplog.Error(errorMessage)
+	gplog.Error("%s", errorMessage)
 	err := gpbckpconfig.UpdateDeleteStatus(backupName, backupStatus, hDB)
 	if err != nil {
-		gplog.Error(textmsg.ErrorTextUnableSetBackupStatus(backupStatus, backupName, err))
+		gplog.Error("%s", textmsg.ErrorTextUnableSetBackupStatus(backupStatus, backupName, err))
 	}
 }

--- a/cmd/wrappers_test.go
+++ b/cmd/wrappers_test.go
@@ -432,7 +432,7 @@ func TestGetBackupMasterDir(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := os.MkdirAll(tt.testDir, 0755)
+			err := os.MkdirAll(tt.testDir, 0o755)
 			if err != nil {
 				t.Fatalf("Failed to create test directory structure: %v", err)
 			}

--- a/e2e_tests/conf/Dockerfile.s3_plugin
+++ b/e2e_tests/conf/Dockerfile.s3_plugin
@@ -4,7 +4,7 @@ ARG S3_PLUGIN_VERSION="1.10.1"
 # to the archive on GitHub. At the same time, all tags have been deleted from the archives.
 # The fork containing the necessary tags is used for testing.
 
-FROM golang:1.23-alpine3.20 AS s3_plugin-builder
+FROM golang:1.24-alpine3.20 AS s3_plugin-builder
 ARG S3_PLUGIN_VERSION
 RUN apk add --no-cache --update build-base bash perl \
     # && wget https://github.com/greenplum-db/gpbackup-s3-plugin/archive/refs/tags/${S3_PLUGIN_VERSION}.tar.gz -O /tmp/gpbackup-s3-plugin-${S3_PLUGIN_VERSION}.tar.gz \

--- a/e2e_tests/conf/Dockerfile.s3_plugin
+++ b/e2e_tests/conf/Dockerfile.s3_plugin
@@ -4,7 +4,7 @@ ARG S3_PLUGIN_VERSION="1.10.1"
 # to the archive on GitHub. At the same time, all tags have been deleted from the archives.
 # The fork containing the necessary tags is used for testing.
 
-FROM golang:1.24-alpine3.20 AS s3_plugin-builder
+FROM golang:1.24-alpine3.21 AS s3_plugin-builder
 ARG S3_PLUGIN_VERSION
 RUN apk add --no-cache --update build-base bash perl \
     # && wget https://github.com/greenplum-db/gpbackup-s3-plugin/archive/refs/tags/${S3_PLUGIN_VERSION}.tar.gz -O /tmp/gpbackup-s3-plugin-${S3_PLUGIN_VERSION}.tar.gz \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/woblerr/gpbackman
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/greenplum-db/gp-common-go-libs v1.0.15

--- a/gpbckpconfig/struct.go
+++ b/gpbckpconfig/struct.go
@@ -118,26 +118,30 @@ func (backupConfig BackupConfig) GetBackupType() (string, error) {
 // In all other cases, an error is returned.
 func (backupConfig BackupConfig) GetObjectFilteringInfo() (string, error) {
 	switch {
-	case backupConfig.IncludeSchemaFiltered && !(backupConfig.ExcludeSchemaFiltered ||
-		backupConfig.IncludeTableFiltered ||
-		backupConfig.ExcludeTableFiltered):
+	case backupConfig.IncludeSchemaFiltered &&
+		!backupConfig.ExcludeSchemaFiltered &&
+		!backupConfig.IncludeTableFiltered &&
+		!backupConfig.ExcludeTableFiltered:
 		return objectFilteringIncludeSchema, nil
-	case backupConfig.ExcludeSchemaFiltered && !(backupConfig.IncludeSchemaFiltered ||
-		backupConfig.IncludeTableFiltered ||
-		backupConfig.ExcludeTableFiltered):
+	case backupConfig.ExcludeSchemaFiltered &&
+		!backupConfig.IncludeSchemaFiltered &&
+		!backupConfig.IncludeTableFiltered &&
+		!backupConfig.ExcludeTableFiltered:
 		return objectFilteringExcludeSchema, nil
-	case backupConfig.IncludeTableFiltered && !(backupConfig.IncludeSchemaFiltered ||
-		backupConfig.ExcludeSchemaFiltered ||
-		backupConfig.ExcludeTableFiltered):
+	case backupConfig.IncludeTableFiltered &&
+		!backupConfig.IncludeSchemaFiltered &&
+		!backupConfig.ExcludeSchemaFiltered &&
+		!backupConfig.ExcludeTableFiltered:
 		return objectFilteringIncludeTable, nil
-	case backupConfig.ExcludeTableFiltered && !(backupConfig.IncludeSchemaFiltered ||
-		backupConfig.ExcludeSchemaFiltered ||
-		backupConfig.IncludeTableFiltered):
+	case backupConfig.ExcludeTableFiltered &&
+		!backupConfig.IncludeSchemaFiltered &&
+		!backupConfig.ExcludeSchemaFiltered &&
+		!backupConfig.IncludeTableFiltered:
 		return objectFilteringExcludeTable, nil
-	case !(backupConfig.ExcludeTableFiltered ||
-		backupConfig.IncludeSchemaFiltered ||
-		backupConfig.ExcludeSchemaFiltered ||
-		backupConfig.IncludeTableFiltered):
+	case !backupConfig.ExcludeTableFiltered &&
+		!backupConfig.IncludeSchemaFiltered &&
+		!backupConfig.ExcludeSchemaFiltered &&
+		!backupConfig.IncludeTableFiltered:
 		return "", nil
 	default:
 		return "", errors.New("backup filtering type does not match any of the available values")

--- a/gpbckpconfig/struct_test.go
+++ b/gpbckpconfig/struct_test.go
@@ -169,6 +169,107 @@ func TestGetObjectFilteringInfo(t *testing.T) {
 			want:    "",
 			wantErr: false,
 		},
+		// Invalid combinations (pairwise conflicts)
+		{
+			name: "Invalid IncludeTable and ExcludeTable",
+			config: BackupConfig{
+				IncludeSchemaFiltered: false,
+				ExcludeSchemaFiltered: false,
+				IncludeTableFiltered:  true,
+				ExcludeTableFiltered:  true,
+			},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name: "Invalid IncludeSchema and ExcludeSchema",
+			config: BackupConfig{
+				IncludeSchemaFiltered: true,
+				ExcludeSchemaFiltered: true,
+				IncludeTableFiltered:  false,
+				ExcludeTableFiltered:  false,
+			},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name: "Invalid IncludeSchema and IncludeTable",
+			config: BackupConfig{
+				IncludeSchemaFiltered: true,
+				ExcludeSchemaFiltered: false,
+				IncludeTableFiltered:  true,
+				ExcludeTableFiltered:  false,
+			},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name: "Invalid IncludeSchema and ExcludeTable",
+			config: BackupConfig{
+				IncludeSchemaFiltered: true,
+				ExcludeSchemaFiltered: false,
+				IncludeTableFiltered:  false,
+				ExcludeTableFiltered:  true,
+			},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name: "Invalid ExcludeSchema and IncludeTable",
+			config: BackupConfig{
+				IncludeSchemaFiltered: false,
+				ExcludeSchemaFiltered: true,
+				IncludeTableFiltered:  true,
+				ExcludeTableFiltered:  false,
+			},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name: "Invalid ExcludeSchema and ExcludeTable",
+			config: BackupConfig{
+				IncludeSchemaFiltered: false,
+				ExcludeSchemaFiltered: true,
+				IncludeTableFiltered:  false,
+				ExcludeTableFiltered:  true,
+			},
+			want:    "",
+			wantErr: true,
+		},
+		// Triple conflicts
+		{
+			name: "Invalid IncludeSchema IncludeTable and ExcludeTable",
+			config: BackupConfig{
+				IncludeSchemaFiltered: true,
+				ExcludeSchemaFiltered: false,
+				IncludeTableFiltered:  true,
+				ExcludeTableFiltered:  true,
+			},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name: "Invalid IncludeSchema ExcludeSchema and IncludeTable",
+			config: BackupConfig{
+				IncludeSchemaFiltered: true,
+				ExcludeSchemaFiltered: true,
+				IncludeTableFiltered:  true,
+				ExcludeTableFiltered:  false,
+			},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name: "Invalid IncludeSchema ExcludeSchema and ExcludeTable",
+			config: BackupConfig{
+				IncludeSchemaFiltered: true,
+				ExcludeSchemaFiltered: true,
+				IncludeTableFiltered:  false,
+				ExcludeTableFiltered:  true,
+			},
+			want:    "",
+			wantErr: true,
+		},
 		{
 			name: "Test InvalidFiltering",
 			config: BackupConfig{
@@ -194,6 +295,10 @@ func TestGetObjectFilteringInfo(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGetObjectFilteringInfoAllCombos(t *testing.T) {
+	// Removed: consolidated into TestGetObjectFilteringInfo
 }
 
 func TestGetBackupDate(t *testing.T) {

--- a/gpbckpconfig/utils_test.go
+++ b/gpbckpconfig/utils_test.go
@@ -392,7 +392,7 @@ func TestCheckMasterBackupDir(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := os.MkdirAll(tt.testDir, 0755)
+			err := os.MkdirAll(tt.testDir, 0o755)
 			if err != nil {
 				t.Fatalf("Failed to create temp dir: %v", err)
 			}


### PR DESCRIPTION
* Updated golangci-lint configuration to `v2` format.
* Upgraded golangci-lint action to `v7` with `v2.3.1`.
* Updated Go version from `1.23` to `1.24`.
* Updated goreleaser from `v2.5.0` to `v2.11.2`.
* Updated alpine from `3.20` to `3.21`.
* Fixed linting and updating issues.