### PR TITLE
Add Ubuntu 24.04 docker image.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,6 +81,30 @@ jobs:
               -t ghcr.io/${GITHUB_USER}/${APP_NAME}:${ref} \
               -t ${DOCKERHUB_USER}/${APP_NAME}:${ref} .
 
+
+      - name: Build alpine image and push master tag to ghcr.io and Docker Hub
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        env:
+          GITHUB_USER: ${{ github.actor }}
+          GITHUB_PKG: ${{ secrets.GUTHUB_CR_PAT }}
+          DOCKERHUB_USER: ${{ secrets.DOCKEHUB_USER }}
+          DOCKERHUB_PKG: ${{ secrets.DOCKEHUB_TOKEN }}
+          GITHUB_SHA: ${{ github.sha}}
+          GITHUB_REF: ${{ github.ref}}
+          BUILD_PLATFORMS: ${{ env.build_platforms }}
+          APP_NAME: ${{ env.app_name }}
+        run: |
+          ref="$(echo ${GITHUB_REF} | cut -d'/' -f3)"
+          sha="$(echo ${GITHUB_SHA} | cut -c1-7)"
+          echo REPO_BUILD_TAG: ${ref}-${sha}
+          echo ${GITHUB_PKG} | docker login ghcr.io -u ${GITHUB_USER} --password-stdin
+          echo ${DOCKERHUB_PKG} | docker login -u ${DOCKERHUB_USER} --password-stdin
+          docker buildx build --push \
+              --build-arg REPO_BUILD_TAG=${ref}-${sha} \
+              --platform ${BUILD_PLATFORMS} \
+              -t ghcr.io/${GITHUB_USER}/${APP_NAME}:${ref}-alpine \
+              -t ${DOCKERHUB_USER}/${APP_NAME}:${ref}-alpine .
+
       - name: Build image and push tag (latest) to ghcr.io and Docker Hub
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
         env:
@@ -105,6 +129,29 @@ jobs:
               -t ghcr.io/${GITHUB_USER}/${APP_NAME}:latest \
               -t ${DOCKERHUB_USER}/${APP_NAME}:${ref} \
               -t ${DOCKERHUB_USER}/${APP_NAME}:latest .
+
+      - name: Build alpine image and push tag to ghcr.io and Docker Hub
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+        env:
+          GITHUB_USER: ${{ github.actor }}
+          GITHUB_PKG: ${{ secrets.GUTHUB_CR_PAT }}
+          DOCKERHUB_USER: ${{ secrets.DOCKEHUB_USER }}
+          DOCKERHUB_PKG: ${{ secrets.DOCKEHUB_TOKEN }}
+          GITHUB_SHA: ${{ github.sha}}
+          GITHUB_REF: ${{ github.ref}}
+          BUILD_PLATFORMS: ${{ env.build_platforms }}
+          APP_NAME: ${{ env.app_name }}
+        run: |
+          ref="$(echo ${GITHUB_REF} | cut -d'/' -f3)"
+          build_ver="$(echo ${ref} | cut -c 2-)"
+          echo REPO_BUILD_TAG: ${build_ver}
+          echo ${GITHUB_PKG} | docker login ghcr.io -u ${GITHUB_USER} --password-stdin
+          echo ${DOCKERHUB_PKG} | docker login -u ${DOCKERHUB_USER} --password-stdin
+          docker buildx build --push \
+              --build-arg REPO_BUILD_TAG=${build_ver} \
+              --platform ${BUILD_PLATFORMS} \
+              -t ghcr.io/${GITHUB_USER}/${APP_NAME}:${ref}-alpine \
+              -t ${DOCKERHUB_USER}/${APP_NAME}:${ref}-alpine .
 
   goreleaser:
     needs: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,6 +100,7 @@ jobs:
           echo ${GITHUB_PKG} | docker login ghcr.io -u ${GITHUB_USER} --password-stdin
           echo ${DOCKERHUB_PKG} | docker login -u ${DOCKERHUB_USER} --password-stdin
           docker buildx build --push \
+              -f Dockerfile.alpine \
               --build-arg REPO_BUILD_TAG=${ref}-${sha} \
               --platform ${BUILD_PLATFORMS} \
               -t ghcr.io/${GITHUB_USER}/${APP_NAME}:${ref}-alpine \
@@ -148,6 +149,7 @@ jobs:
           echo ${GITHUB_PKG} | docker login ghcr.io -u ${GITHUB_USER} --password-stdin
           echo ${DOCKERHUB_PKG} | docker login -u ${DOCKERHUB_USER} --password-stdin
           docker buildx build --push \
+              -f Dockerfile.alpine \
               --build-arg REPO_BUILD_TAG=${build_ver} \
               --platform ${BUILD_PLATFORMS} \
               -t ghcr.io/${GITHUB_USER}/${APP_NAME}:${ref}-alpine \

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,10 @@ RUN apt-get update \
         tzdata \
     && groupadd --gid ${GPBACKMAN_GID} ${GPBACKMAN_GROUP} \
     && useradd --shell /bin/bash -d /home/${GPBACKMAN_USER} --uid ${GPBACKMAN_UID} --gid ${GPBACKMAN_GID} -m ${GPBACKMAN_USER} \
+    && unlink /etc/localtime \
     && cp /usr/share/zoneinfo/${TZ} /etc/localtime \
     && echo "${TZ}" > /etc/timezone \
+    && apt-get autoremove -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 COPY --chmod=755 docker_files/entrypoint.sh /entrypoint.sh

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,36 +1,34 @@
 ARG REPO_BUILD_TAG="unknown"
 
-FROM golang:1.24-bookworm AS builder
+FROM golang:1.24-alpine3.21 AS builder
 ARG REPO_BUILD_TAG
 COPY . /build
 WORKDIR /build
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends build-essential \
+RUN apk add --no-cache --update build-base \
     && CGO_ENABLED=1 go build \
         -mod=vendor -trimpath \
         -ldflags "-X main.version=${REPO_BUILD_TAG}" \
-        -o gpbackman gpbackman.go \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+        -o gpbackman gpbackman.go
 
-FROM ubuntu:24.04
+FROM alpine:3.21
 ARG REPO_BUILD_TAG
 ENV TZ="Etc/UTC" \
     GPBACKMAN_USER="gpbackman" \
     GPBACKMAN_GROUP="gpbackman" \
     GPBACKMAN_UID=1001 \
     GPBACKMAN_GID=1001
-RUN apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+RUN apk add --no-cache --update \
+        bash \
+        shadow \
         ca-certificates \
-        gosu \
+        su-exec \
         tzdata \
+    && ln -s /sbin/su-exec /usr/local/bin/gosu \
     && groupadd --gid ${GPBACKMAN_GID} ${GPBACKMAN_GROUP} \
     && useradd --shell /bin/bash -d /home/${GPBACKMAN_USER} --uid ${GPBACKMAN_UID} --gid ${GPBACKMAN_GID} -m ${GPBACKMAN_USER} \
     && cp /usr/share/zoneinfo/${TZ} /etc/localtime \
     && echo "${TZ}" > /etc/timezone \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/cache/apk/*
 COPY --chmod=755 docker_files/entrypoint.sh /entrypoint.sh
 COPY --from=builder /build/gpbackman /usr/bin/gpbackman
 LABEL \

--- a/Makefile
+++ b/Makefile
@@ -110,6 +110,12 @@ docker:
 	@echo "Version $(BRANCH)-$(GIT_REV)"
 	DOCKER_BUILDKIT=1 docker build --pull -f Dockerfile --build-arg REPO_BUILD_TAG=$(BRANCH)-$(GIT_REV) -t $(APP_NAME) .
 
+.PHONY: docker-alpine
+docker-alpine:
+	@echo "Build $(APP_NAME) alpine docker container"
+	@echo "Version $(BRANCH)-$(GIT_REV)"
+	DOCKER_BUILDKIT=1 docker build --pull -f Dockerfile.alpine --build-arg REPO_BUILD_TAG=$(BRANCH)-$(GIT_REV) -t $(APP_NAME)-alpine .
+
 define e2e_command
 	@echo "Run end-to-end tests for $(APP_NAME) for ${1} command"
 	docker run --rm -v $(ROOT_DIR)/e2e_tests/:/home/gpbackman/e2e_tests --name="$(APP_NAME)" "$(APP_NAME)" /home/gpbackman/e2e_tests/run_e2e_${1}.sh

--- a/README.md
+++ b/README.md
@@ -76,9 +76,9 @@ make build
 Environment variables supported by this image:
 * `TZ` - container's time zone, default `Etc/UTC`;
 * `GPBACKMAN_USER` - non-root user name for execution of the command, default `gpbackman`;
+* `GPBACKMAN_GROUP` - non-root user group name for execution of the command, default `gpbackman`;
 * `GPBACKMAN_UID` - UID of internal `${GPBACKMAN_USER}` user, default `1001`;
 * `GPBACKMAN_GID` - GID of internal `${GPBACKMAN_USER}` user, default `1001`.
-
 
 #### Build container
 
@@ -92,12 +92,23 @@ or manual:
 docker build  -f Dockerfile  -t gpbackman .
 ```
 
+For Alpine image:
+
+```bash
+make docker-alpine
+```
+or manual:
+
+```bash
+docker build  -f Dockerfile.alpine  -t gpbackman-alpine .
+```
+
 #### Run container
 
 ```bash
 docker run \
   --name gpbackman \
-  -v /data/master/gpseg-1/gpbackup_history.db:/data/master/gpseg-1/gpbackup_history.db
+  -v /data/master/gpseg-1/gpbackup_history.db:/data/master/gpseg-1/gpbackup_history.db \
   gpbackman \
   gpbackman backup-info \
   --history-db /data/master/gpseg-1/gpbackup_history.db

--- a/docker_files/entrypoint.sh
+++ b/docker_files/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 uid=$(id -u)
 
@@ -8,16 +8,19 @@ if [ "${uid}" = "0" ]; then
         cp /usr/share/zoneinfo/${TZ} /etc/localtime
         echo "${TZ}" > /etc/timezone
     fi
-
-    # Set custom user UID or GID.
-    if  [ "${GPBACKMAN_UID}" != "1001" ] || [ "${GPBACKMAN_GID}" != "1001" ] ; then
-        sed -i "s/:1001:1001:/:${GPBACKMAN_UID}:${GPBACKMAN_GID}:/g" /etc/passwd
+    # Custom user group.
+    if [ "${GPBACKMAN_GROUP}" != "gpbackman" ] || [ "${GPBACKMAN_GID}" != "1001" ]; then
+        groupmod -g ${GPBACKMAN_GID} -n ${GPBACKMAN_GROUP} gpbackman
     fi
-    chown -R ${GPBACKMAN_USER}:${GPBACKMAN_USER} /home/${GPBACKMAN_USER} 
+    # Custom user.
+    if [ "${GPBACKMAN_USER}" != "gpbackman" ] || [ "${GPBACKMAN_UID}" != "1001" ]; then
+        usermod -g ${GPBACKMAN_GID} -l ${GPBACKMAN_USER} -u ${GPBACKMAN_UID} -m -d /home/${GPBACKMAN_USER} gpbackman
+    fi
+    chown -R ${GPBACKMAN_USER}:${GPBACKMAN_GROUP} /home/${GPBACKMAN_USER} 
 fi
 
 if [ "${uid}" = "0" ]; then
-    exec su-exec ${GPBACKMAN_USER} "$@"
+    exec gosu ${GPBACKMAN_USER} "$@"
 else
     exec "$@"
 fi

--- a/e2e_tests/conf/Dockerfile.s3_plugin
+++ b/e2e_tests/conf/Dockerfile.s3_plugin
@@ -4,15 +4,18 @@ ARG S3_PLUGIN_VERSION="1.10.1"
 # to the archive on GitHub. At the same time, all tags have been deleted from the archives.
 # The fork containing the necessary tags is used for testing.
 
-FROM golang:1.24-alpine3.21 AS s3_plugin-builder
+FROM golang:1.24-bookworm AS s3_plugin-builder
 ARG S3_PLUGIN_VERSION
-RUN apk add --no-cache --update build-base bash perl \
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential bash perl wget ca-certificates \
     # && wget https://github.com/greenplum-db/gpbackup-s3-plugin/archive/refs/tags/${S3_PLUGIN_VERSION}.tar.gz -O /tmp/gpbackup-s3-plugin-${S3_PLUGIN_VERSION}.tar.gz \
     && wget https://github.com/woblerr/gpbackup-s3-plugin/archive/refs/tags/${S3_PLUGIN_VERSION}.tar.gz -O /tmp/gpbackup-s3-plugin-${S3_PLUGIN_VERSION}.tar.gz \
     && mkdir -p /tmp/gpbackup-s3-plugin \
     && tar -xzf  /tmp/gpbackup-s3-plugin-${S3_PLUGIN_VERSION}.tar.gz --strip-components=1 -C /tmp/gpbackup-s3-plugin \
     && cd /tmp/gpbackup-s3-plugin \
-    && make build
+    && make build \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 FROM gpbackman AS gpbackman-plugins
 COPY --from=s3_plugin-builder /go/bin/gpbackup_s3_plugin /home/gpbackman/gpbackup_s3_plugin


### PR DESCRIPTION
* Switch main Dockerfile from Alpine `3.21` to Ubuntu `24.04`.
* Add separate Dockerfile.alpine for Alpine support.
* Update entrypoint.sh for cross-platform compatibility:
  - Change shebang from `/bin/sh` to `/usr/bin/env bash`
  - Replace `su-exec` with `gosu` (unified across platforms)
  - Improve user/group management with usermod/groupmod
* Update CI to build both Ubuntu and Alpine images
* Update `Dockerfile.s3_plugin` from Alpine to Debian/Ubuntu
* Update README with new environment variables (`GPBACKMAN_GROUP`)

Ubuntu uses standard `glibc`, Alpine is based on `musl libc`. This may impose restrictions, so an Ubuntu-based image is added.  The  Debian based`*-bookworm` image is used to build binary  go file.