### PR TITLE
Add --timestamp and --detail options for backup-info command.

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -393,7 +393,7 @@ Display info for active full backups from `gpbackup_history.db`:
 ./gpbackman backup-info \
   --type full
 
-TIMESTAMP      | DATE                     | STATUS  | DATABASE | TYPE | OBJECT FILTERING | PLUGIN             | DURATION | DATE DELETED 
+ TIMESTAMP      | DATE                     | STATUS  | DATABASE | TYPE | OBJECT FILTERING | PLUGIN             | DURATION | DATE DELETED 
 ----------------+--------------------------+---------+----------+------+------------------+--------------------+----------+--------------
  20230809232817 | Wed Aug 09 2023 23:28:17 | Success | demo     | full |                  |                    | 04:00:03 |              
  20230725101115 | Tue Jul 25 2023 10:11:15 | Success | demo     | full |                  | gpbackup_s3_plugin | 00:00:20 |              
@@ -408,7 +408,7 @@ Find all backups, including deleted ones, containing the `test1` schema.
   --deleted \
   --schema test1
 
-TIMESTAMP      | DATE                     | STATUS  | DATABASE | TYPE        | OBJECT FILTERING | PLUGIN             | DURATION | DATE DELETED             
+ TIMESTAMP      | DATE                     | STATUS  | DATABASE | TYPE        | OBJECT FILTERING | PLUGIN             | DURATION | DATE DELETED             
 ----------------+--------------------------+---------+----------+-------------+------------------+--------------------+----------+--------------------------
  20230525101152 | Thu May 25 2023 10:11:52 | Success | demo     | incremental | include-schema   | gpbackup_s3_plugin | 00:30:00 | Sun Jun 25 2023 10:11:52 
  20230524101152 | Wed May 24 2023 10:11:52 | Success | demo     | incremental | include-schema   | gpbackup_s3_plugin | 00:30:00 |                          
@@ -422,7 +422,7 @@ Display info for all backups, including deleted and failed ones, from `gpbackup_
   --failed \
   --history-db /data/master/gpseg-1/gpbackup_history.db
 
-TIMESTAMP      | DATE                     | STATUS  | DATABASE | TYPE          | OBJECT FILTERING | PLUGIN             | DURATION | DATE DELETED                
+ TIMESTAMP      | DATE                     | STATUS  | DATABASE | TYPE          | OBJECT FILTERING | PLUGIN             | DURATION | DATE DELETED                
 ----------------+--------------------------+---------+----------+---------------+------------------+--------------------+----------+-----------------------------
  20230809232817 | Wed Aug 09 2023 23:28:17 | Success | demo     | full          |                  |                    | 04:00:03 |                             
  20230806230400 | Sun Aug 06 2023 23:04:00 | Failure | demo     | full          |                  | gpbackup_s3_plugin | 00:00:38 |                             
@@ -453,7 +453,7 @@ Display full backup with object filtering details:
   --type full \
   --detail
 
-TIMESTAMP      | DATE                     | STATUS  | DATABASE | TYPE | OBJECT FILTERING | PLUGIN             | DURATION | DATE DELETED | OBJECT FILTERING DETAILS 
+ TIMESTAMP      | DATE                     | STATUS  | DATABASE | TYPE | OBJECT FILTERING | PLUGIN             | DURATION | DATE DELETED | OBJECT FILTERING DETAILS 
 ----------------+--------------------------+---------+----------+------+------------------+--------------------+----------+--------------+--------------------------
  20250915221743 | Mon Sep 15 2025 22:17:43 | Success | demo     | full |                  |                    | 00:00:01 |              |                          
  20250915221643 | Mon Sep 15 2025 22:16:43 | Success | demo     | full | exclude-schema   | gpbackup_s3_plugin | 00:00:01 |              | sch1                     

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -270,7 +270,6 @@ Display information about backups.
 
 By default, only active backups or backups with deletion status "In progress" from gpbackup_history.db are displayed.
 
-
 To display deleted backups, use the --deleted option.
 To display failed backups, use the --failed option.
 To display all backups, use --deleted and --failed options together.
@@ -289,13 +288,19 @@ The formatting rules for <schema>.<table> match those of the --exclude-table opt
 To display backups that exclude the specified schema, use the --schema and --exclude options. 
 The formatting rules for <schema> match those of the --exclude-schema option in gpbackup.
 
-To display a backup chain for a specific backup, use the --timestamp option.
-In this mode, the backup with the specified timestamp and all of its dependent backups will be displayed.
-When --timestamp is set, the following options cannot be used: --type, --table, --schema, --exclude, --failed, --deleted.
-Details about object filtering are presented as follows, depending on the active filtering type:
+To display details about object filtering, use the --detail option.
+The details are presented as follows, depending on the active filtering type:
   * include-table / exclude-table: a comma-separated list of fully-qualified table names in the format <schema>.<table>;
   * include-schema / exclude-schema: a comma-separated list of schema names;
   * if no object filtering was used, the value is empty.
+
+To display a backup chain for a specific backup, use the --timestamp option.
+In this mode, the backup with the specified timestamp and all of its dependent backups will be displayed.
+The deleted and failed backups are always included in this mode.
+The information about object filtering details is always included in this mode.
+When --timestamp is set, the following options cannot be used: --type, --table, --schema, --exclude, --failed, --deleted, --detail.
+
+To display the "object filtering details" column for all backups without using --timestamp, use the --detail option.
 
 The gpbackup_history.db file location can be set using the --history-db option.
 Can be specified only once. The full path to the file is required.
@@ -306,6 +311,7 @@ Usage:
 
 Flags:
       --deleted            show deleted backups
+      --detail             show object filtering details
       --exclude            show backups that exclude the specific table (format <schema>.<table>) or schema
       --failed             show failed backups
   -h, --help               help for backup-info
@@ -440,6 +446,24 @@ TIMESTAMP      | DATE                     | STATUS  | DATABASE | TYPE          |
  20230524101152 | Wed May 24 2023 10:11:52 | Success | demo     | incremental   | include-schema   | gpbackup_s3_plugin | 00:30:00 |                             
  20230523101115 | Tue May 23 2023 10:11:15 | Success | demo     | full          | include-schema   | gpbackup_s3_plugin | 01:01:00 |                             
  ```
+
+Display full backup with object filtering details:
+```bash
+./gpbackman backup-info \
+  --type full \
+  --detail
+
+TIMESTAMP      | DATE                     | STATUS  | DATABASE | TYPE | OBJECT FILTERING | PLUGIN             | DURATION | DATE DELETED | OBJECT FILTERING DETAILS 
+----------------+--------------------------+---------+----------+------+------------------+--------------------+----------+--------------+--------------------------
+ 20250915221743 | Mon Sep 15 2025 22:17:43 | Success | demo     | full |                  |                    | 00:00:01 |              |                          
+ 20250915221643 | Mon Sep 15 2025 22:16:43 | Success | demo     | full | exclude-schema   | gpbackup_s3_plugin | 00:00:01 |              | sch1                     
+ 20250915221631 | Mon Sep 15 2025 22:16:31 | Success | demo     | full | include-table    | gpbackup_s3_plugin | 00:00:01 |              | sch2.tbl_c, sch2.tbl_d   
+ 20250915221616 | Mon Sep 15 2025 22:16:16 | Success | demo     | full |                  | gpbackup_s3_plugin | 00:00:05 |              |                          
+ 20250915221553 | Mon Sep 15 2025 22:15:53 | Success | demo     | full | exclude-table    |                    | 00:00:02 |              | sch1.tbl_b               
+ 20250915221542 | Mon Sep 15 2025 22:15:42 | Success | demo     | full | include-table    |                    | 00:00:01 |              | sch1.tbl_a               
+ 20250915221531 | Mon Sep 15 2025 22:15:31 | Success | demo     | full |                  |                    | 00:00:01 |              |                          
+
+```
 
 Display info for the backup chain for a specific backup. In this example, the backup with timestamp `20250913210921` is a full backup, and all its dependent incremental backups are displayed as well:
 ```bash

--- a/cmd/backup_info.go
+++ b/cmd/backup_info.go
@@ -285,7 +285,7 @@ func initTable(t table.Writer, includeDetails bool) {
 // If errors occur, they are logged, but they are not returned.
 // The main idea is to show the maximum available information and display all errors that occur.
 // But do not fall when errors occur. So, display anyway.
-func addBackupToTable(backupTypeFilter, backupTableFilter, backupSchemaFilter string, backupExcludeFilter bool, includeDetails bool, backupData gpbckpconfig.BackupConfig, t table.Writer) {
+func addBackupToTable(backupTypeFilter, backupTableFilter, backupSchemaFilter string, backupExcludeFilter, includeDetails bool, backupData gpbckpconfig.BackupConfig, t table.Writer) {
 	var matchToObjectFilter bool
 	backupDate, err := backupData.GetBackupDate()
 	if err != nil {

--- a/cmd/constants.go
+++ b/cmd/constants.go
@@ -40,6 +40,7 @@ const (
 	backupDirFlagName            = "backup-dir"
 	parallelProcessesFlagName    = "parallel-processes"
 	ignoreErrorsFlagName         = "ignore-errors"
+	detailFlagName               = "detail"
 
 	exitErrorCode = 1
 

--- a/e2e_tests/README.md
+++ b/e2e_tests/README.md
@@ -2,7 +2,7 @@
 
 The following architecture is used to run the tests:
 
-* Separate containers for MinIO and nginx. Official images [minio/minio](https://hub.docker.com/r/minio/minio), [minio/mc](https://hub.docker.com/r/minio/mc) and [nginx](https://hub.docker.com/_/nginx) are used. It's necessary for S3 compatible storage for WAL archiving and backups.
+* Separate containers for MinIO and nginx. Official images [minio/minio](https://hub.docker.com/r/minio/minio), [minio/mc](https://hub.docker.com/r/minio/mc) and [nginx](https://hub.docker.com/_/nginx) are used. It's necessary for S3 compatible storage for backups.
 - Separate container gpbackman-export: runs the gpbackman image and copies the binary to a shared Docker volume (gpbackman_bin) for use inside the Greenplum container.
 * Separate container for Greenplum. The [docker-greenplum image](https://github.com/woblerr/docker-greenplum) is used to run a single-node Greenplum cluster.
 

--- a/e2e_tests/scripts/prepare/prepare_gpdb_backups.sh
+++ b/e2e_tests/scripts/prepare/prepare_gpdb_backups.sh
@@ -7,13 +7,13 @@ set -Eeuo pipefail
 # 3.  full_local_exclude_table : Full LOCAL backup excluding sch1.tbl_b
 # 4.  metadata_only_s3         : Metadata-only S3 backup (no data)
 # 5.  full_s3                  : Full S3 backup (all tables, leaf partition data)
-# 6.  full_s3_include_table    : Full S3 backup including only sch2.tbl_c
-# 7.  full_s3_exclude_table    : Full S3 backup excluding sch2.tbl_d
+# 6.  full_s3_include_tables   : Full S3 backup including sch2.tbl_c, sch2.tbl_d
+# 7.  full_s3_exclude_schema   : Full S3 backup excluding schema sch1
 # 8.  (data change)            : Insert into sch2.tbl_c and sch2.tbl_d
 # 9.  incr_s3                  : Incremental S3 backup
-# 10. incr_s3_include_table    : Incremental S3 backup including only sch2.tbl_c
+# 10. incr_s3_include_tables   : Incremental S3 backup including sch2.tbl_c, sch2.tbl_d
 # 11. (data change)            : Insert more rows into sch2.tbl_c
-# 12. incr_s3_exclude_table    : Incremental S3 backup excluding sch2.tbl_d
+# 12. incr_s3_exclude_schema   : Incremental S3 backup excluding schema sch1
 # 13. data_only_local          : Data-only LOCAL backup (no metadata)
 # 14. full_local               : Final full LOCAL backup (all tables)
 
@@ -43,11 +43,11 @@ run_backup metadata_only_s3 "${COMMON_PLUGIN_FLAGS[@]}" --metadata-only
 # Full S3 no filters
 run_backup full_s3 "${COMMON_PLUGIN_FLAGS[@]}" --leaf-partition-data
 
-# Full S3 include-table sch2.tbl_c
-run_backup full_s3_include_table "${COMMON_PLUGIN_FLAGS[@]}" --include-table sch2.tbl_c --leaf-partition-data
+# Full S3 include-table sch2.tbl_c, sch2.tbl_d
+run_backup full_s3_include_table "${COMMON_PLUGIN_FLAGS[@]}" --include-table sch2.tbl_c --include-table sch2.tbl_d --leaf-partition-data
 
-# Full S3 exclude-table sch2.tbl_d
-run_backup full_s3_exclude_table "${COMMON_PLUGIN_FLAGS[@]}" --exclude-table sch2.tbl_d --leaf-partition-data
+# Full S3 exclude-schema sch1
+run_backup full_s3_exclude_schema "${COMMON_PLUGIN_FLAGS[@]}" --exclude-schema sch1 --leaf-partition-data
 
 # Insert data
 psql -d demo -c "INSERT INTO sch2.tbl_c SELECT i, i FROM generate_series(1,100000) i;"
@@ -56,14 +56,14 @@ psql -d demo -c "INSERT INTO sch2.tbl_d SELECT i, i FROM generate_series(1,10000
 # Incremental S3 no filters
 run_backup incr_s3 "${COMMON_PLUGIN_FLAGS[@]}" --incremental --leaf-partition-data
 
-# Incremental S3 include-table sch2.tbl_c
-run_backup incr_s3_include_table "${COMMON_PLUGIN_FLAGS[@]}" --incremental --include-table sch2.tbl_c --leaf-partition-data
+# Incremental S3 include-tables sch2.tbl_c, sch2.tbl_d
+run_backup incr_s3_include_table "${COMMON_PLUGIN_FLAGS[@]}" --incremental --include-table sch2.tbl_c --include-table sch2.tbl_d --leaf-partition-data
 
 # Insert data
 psql -d demo -c "INSERT INTO sch2.tbl_c SELECT i, i FROM generate_series(1,100000) i;"
 
-# Incremental S3 exclude-table sch2.tbl_d
-run_backup incr_s3_exclude_table "${COMMON_PLUGIN_FLAGS[@]}" --incremental --exclude-table sch2.tbl_d --leaf-partition-data
+# Incremental S3 exclude-schema sch1
+run_backup incr_s3_exclude_schema "${COMMON_PLUGIN_FLAGS[@]}" --incremental --exclude-schema sch1 --leaf-partition-data
 
 # Data-only LOCAL no filters
 run_backup data_only_local --data-only

--- a/e2e_tests/scripts/run_tests/run_backup-info.sh
+++ b/e2e_tests/scripts/run_tests/run_backup-info.sh
@@ -42,10 +42,10 @@ test_count_include_table_backups() {
     assert_equals "${want}" "${got}"
 }
 
-# Test 5: Count backups that exclude table sch2.tbl_d
-test_count_exclude_table_backups() {
+# Test 5: Count backups that exclude schema sch1
+test_count_exclude_schema_backups() {
     local want=2
-    local got=$(get_backup_info total_exclude_table_backups --history-db ${DATA_DIR}/gpbackup_history.db --table sch2.tbl_d --exclude | grep -E "${TIMESTAMP_GREP_PATTERN}" | wc -l)
+    local got=$(get_backup_info total_exclude_schema_backups --history-db ${DATA_DIR}/gpbackup_history.db --schema sch1 --exclude | grep -E "${TIMESTAMP_GREP_PATTERN}" | wc -l)
     assert_equals "${want}" "${got}"
 }
 
@@ -57,10 +57,10 @@ test_count_include_table_full_backups() {
     assert_equals "${want}" "${got}"
 }
 
-# Test 7: Count incremental backups that exclude table sch2.tbl_d
-test_count_exclude_table_incremental_backups() {
+# Test 7: Count incremental backups that exclude schema sch1
+test_count_exclude_schema_incremental_backups() {
     local want=1
-    local got=$(get_backup_info total_exclude_table_incremental_backups --history-db ${DATA_DIR}/gpbackup_history.db --table sch2.tbl_d --exclude --type incremental | grep -E "${TIMESTAMP_GREP_PATTERN}" | wc -l)
+    local got=$(get_backup_info total_exclude_schema_incremental_backups --history-db ${DATA_DIR}/gpbackup_history.db --schema sch1 --exclude --type incremental | grep -E "${TIMESTAMP_GREP_PATTERN}" | wc -l)
     assert_equals "${want}" "${got}"
 }
 
@@ -95,9 +95,9 @@ run_test "${COMMAND}" 1 test_count_all_backups
 run_test "${COMMAND}" 2 test_count_full_backups
 run_test "${COMMAND}" 3 test_count_incremental_backups
 run_test "${COMMAND}" 4 test_count_include_table_backups
-run_test "${COMMAND}" 5 test_count_exclude_table_backups
+run_test "${COMMAND}" 5 test_count_exclude_schema_backups
 run_test "${COMMAND}" 6 test_count_include_table_full_backups
-run_test "${COMMAND}" 7 test_count_exclude_table_incremental_backups
+run_test "${COMMAND}" 7 test_count_exclude_schema_incremental_backups
 run_test "${COMMAND}" 8 test_backup_chain_include_tables
 run_test "${COMMAND}" 9 test_backup_chain_incremental_exclude
 

--- a/e2e_tests/scripts/run_tests/run_backup-info.sh
+++ b/e2e_tests/scripts/run_tests/run_backup-info.sh
@@ -91,6 +91,18 @@ test_backup_chain_incremental_exclude() {
     fi
 }
 
+# Test 10: Check full local backup with include table sch1.tbl_a and object filtering details
+test_full_local_include_table_details() {
+    local want=1
+    local got=$(get_backup_info full_local_include_table_details --history-db ${DATA_DIR}/gpbackup_history.db --table sch1.tbl_a --type full --detail | grep -E "${TIMESTAMP_GREP_PATTERN}" | wc -l)
+    assert_equals "${want}" "${got}"
+    local got_details=$(get_backup_info full_local_include_table_details --history-db ${DATA_DIR}/gpbackup_history.db --table sch1.tbl_a --type full --detail| grep -E "${TIMESTAMP_GREP_PATTERN}" | awk -F'|' '{print $NF}')
+    if [ ! -n "${got_details}" ]; then
+        echo "[ERROR] Expected details column to be non-empty"
+        exit 1
+    fi
+}
+
 run_test "${COMMAND}" 1 test_count_all_backups
 run_test "${COMMAND}" 2 test_count_full_backups
 run_test "${COMMAND}" 3 test_count_incremental_backups
@@ -100,5 +112,6 @@ run_test "${COMMAND}" 6 test_count_include_table_full_backups
 run_test "${COMMAND}" 7 test_count_exclude_schema_incremental_backups
 run_test "${COMMAND}" 8 test_backup_chain_include_tables
 run_test "${COMMAND}" 9 test_backup_chain_incremental_exclude
+run_test "${COMMAND}" 10 test_full_local_include_table_details
 
 log_all_tests_passed "${COMMAND}"

--- a/gpbckpconfig/struct.go
+++ b/gpbckpconfig/struct.go
@@ -2,6 +2,7 @@ package gpbckpconfig
 
 import (
 	"errors"
+	"strings"
 	"time"
 )
 
@@ -145,6 +146,24 @@ func (backupConfig BackupConfig) GetObjectFilteringInfo() (string, error) {
 		return "", nil
 	default:
 		return "", errors.New("backup filtering type does not match any of the available values")
+	}
+}
+
+// GetObjectFilteringDetails returns a comma-separated string with object filtering details
+// depending on the active filtering type. If no filtering is active, it returns an empty string.
+func (backupConfig BackupConfig) GetObjectFilteringDetails() string {
+	filter, _ := backupConfig.GetObjectFilteringInfo()
+	switch filter {
+	case objectFilteringIncludeTable:
+		return strings.Join(backupConfig.IncludeRelations, ", ")
+	case objectFilteringExcludeTable:
+		return strings.Join(backupConfig.ExcludeRelations, ", ")
+	case objectFilteringIncludeSchema:
+		return strings.Join(backupConfig.IncludeSchemas, ", ")
+	case objectFilteringExcludeSchema:
+		return strings.Join(backupConfig.ExcludeSchemas, ", ")
+	default:
+		return ""
 	}
 }
 

--- a/gpbckpconfig/struct_test.go
+++ b/gpbckpconfig/struct_test.go
@@ -297,8 +297,58 @@ func TestGetObjectFilteringInfo(t *testing.T) {
 	}
 }
 
-func TestGetObjectFilteringInfoAllCombos(t *testing.T) {
-	// Removed: consolidated into TestGetObjectFilteringInfo
+func TestGetObjectFilteringDetails(t *testing.T) {
+	tests := []struct {
+		name   string
+		config BackupConfig
+		want   string
+	}{
+		{
+			name: "IncludeTable details",
+			config: BackupConfig{
+				IncludeTableFiltered: true,
+				IncludeRelations:     []string{"public.t1", "s.t2"},
+			},
+			want: "public.t1, s.t2",
+		},
+		{
+			name: "ExcludeTable details",
+			config: BackupConfig{
+				ExcludeTableFiltered: true,
+				ExcludeRelations:     []string{"public.t3"},
+			},
+			want: "public.t3",
+		},
+		{
+			name: "IncludeSchema details",
+			config: BackupConfig{
+				IncludeSchemaFiltered: true,
+				IncludeSchemas:        []string{"public", "sales"},
+			},
+			want: "public, sales",
+		},
+		{
+			name: "ExcludeSchema details",
+			config: BackupConfig{
+				ExcludeSchemaFiltered: true,
+				ExcludeSchemas:        []string{"tmp"},
+			},
+			want: "tmp",
+		},
+		{
+			name:   "No filtering",
+			config: BackupConfig{},
+			want:   "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.config.GetObjectFilteringDetails()
+			if got != tt.want {
+				t.Errorf("\nVariables do not match:\n%v\nwant:\n%v", got, tt.want)
+			}
+		})
+	}
 }
 
 func TestGetBackupDate(t *testing.T) {


### PR DESCRIPTION
- Added `--detail` option for `backup-info` command:
Adds the `object filtering details` column.
When `--detail` is set, each row shows:
  * include-table / exclude-table: a comma-separated list of fully-qualified tables in the form `<schema>.<table>`;
  * include-schema / exclude-schema: a comma-separated list of schema names;
  * empty value if no object filtering was used.

- Added `--timestamp` option for `backup-info` command:
    * Shows the backup with the given timestamp and all its dependent backups.
    * Always includes deleted and failed backups.
    * Always adds the `object filtering details` column.

* Updated docs and tests.