### PR TITLE
Fix panic: send on closed channel.

### DIFF
--- a/cmd/backup_delete.go
+++ b/cmd/backup_delete.go
@@ -423,13 +423,12 @@ func execDeleteBackupPlugin(executablePath, deleteBackupPluginCommand, pluginCon
 // ExecuteCommandsOnHosts Delete backup dir on all segment hosts in parallel.
 // The function checks that the directories exists on all segment hosts before deletion.
 func executeDeleteBackupOnSegments(backupDir, backupDataBackupDir, backupName, segPrefix string, isSingleBackupDir, ignoreErrors bool, configs []gpbckpconfig.SegmentConfig, maxParallelProcesses int) error {
-	var once sync.Once
 	limit := make(chan bool, maxParallelProcesses)
-	wg := &sync.WaitGroup{}
-	errCh := make(chan error, len(configs))
 	currentUser, _ := operating.System.CurrentUser()
 	userName := currentUser.Username
 	// Check that the directory exists on all segment hosts.
+	checkErrCh := make(chan error, len(configs))
+	wg := &sync.WaitGroup{}
 	for _, config := range configs {
 		wg.Add(1)
 		limit <- true
@@ -440,7 +439,7 @@ func executeDeleteBackupOnSegments(backupDir, backupDataBackupDir, backupName, s
 		go func(backupPath, host string) {
 			defer func() { <-limit }()
 			defer wg.Done()
-			checkBackupDirExistsOnSegments(gpbckpconfig.BackupDirPath(backupPath, backupName), host, userName, errCh)
+			checkBackupDirExistsOnSegments(gpbckpconfig.BackupDirPath(backupPath, backupName), host, userName, checkErrCh)
 		}(backupPath, config.Hostname)
 	}
 	// We should block the main function and wait for the WaitGroup to complete.
@@ -451,20 +450,18 @@ func executeDeleteBackupOnSegments(backupDir, backupDataBackupDir, backupName, s
 	// and deletion occurs for another.
 	//
 	// Don't use code like
-	// go func() { wg.Wait(); once.Do(func() { close(errCh) }) }()
+	// go func() { wg.Wait(); close(checkErrCh) }()
 	//
 	wg.Wait()
-	// Fix error like "panic: close of closed channel".
-	once.Do(func() {
-		close(errCh)
-	})
-	for err := range errCh {
+	close(checkErrCh)
+	for err := range checkErrCh {
 		if err != nil && !ignoreErrors {
 			return err
 		}
 	}
 	// If all checks passed, delete the directory on all segment hosts.
-	// Reset the wait group.
+	// Use a fresh channel and wait group for the delete phase.
+	deleteErrCh := make(chan error, len(configs))
 	wg = &sync.WaitGroup{}
 	for _, config := range configs {
 		wg.Add(1)
@@ -476,15 +473,12 @@ func executeDeleteBackupOnSegments(backupDir, backupDataBackupDir, backupName, s
 		go func(backupPath, host string) {
 			defer func() { <-limit }()
 			defer wg.Done()
-			deleteBackupDirOnSegments(gpbckpconfig.BackupDirPath(backupPath, backupName), host, userName, errCh)
+			deleteBackupDirOnSegments(gpbckpconfig.BackupDirPath(backupPath, backupName), host, userName, deleteErrCh)
 		}(backupPath, config.Hostname)
 	}
 	wg.Wait()
-	// Fix error like "panic: close of closed channel".
-	once.Do(func() {
-		close(errCh)
-	})
-	for err := range errCh {
+	close(deleteErrCh)
+	for err := range deleteErrCh {
 		if err != nil && !ignoreErrors {
 			return err
 		}

--- a/cmd/backup_delete_test.go
+++ b/cmd/backup_delete_test.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"fmt"
 	"os/exec"
 	"strings"
 	"testing"
@@ -75,25 +74,4 @@ func TestExecuteDeleteBackupOnSegments(t *testing.T) {
 			}
 		})
 	}
-}
-
-// TestDeleteBackupDirOnSegments_ClosedChannel reproduces the original bug directly:
-// sending an error to an already-closed channel should panic.
-func TestDeleteBackupDirOnSegments_ClosedChannel(t *testing.T) {
-	testhelper.SetupTestLogger()
-	origExecCommand := execCommand
-	defer func() { execCommand = origExecCommand }()
-	execCommand = func(command string, args ...string) *exec.Cmd {
-		return exec.Command("false")
-	}
-	errCh := make(chan error, 1)
-	close(errCh)
-	defer func() {
-		if r := recover(); r != nil {
-			if msg := fmt.Sprintf("%v", r); !strings.Contains(msg, "send on closed channel") {
-				t.Errorf("unexpected panic: %v", r)
-			}
-		}
-	}()
-	deleteBackupDirOnSegments("/some/path", "host1", "user", errCh)
 }

--- a/cmd/backup_delete_test.go
+++ b/cmd/backup_delete_test.go
@@ -1,0 +1,99 @@
+package cmd
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/greenplum-db/gp-common-go-libs/testhelper"
+	"github.com/woblerr/gpbackman/gpbckpconfig"
+)
+
+// fakeExecCommand returns a function that mocks execCommand.
+// If failOnRmRf is true, SSH commands containing "rm -rf" will fail.
+func fakeExecCommand(failOnRmRf bool) func(string, ...string) *exec.Cmd {
+	return func(command string, args ...string) *exec.Cmd {
+		if command == "ssh" && len(args) > 0 {
+			remoteCmd := args[len(args)-1]
+			if failOnRmRf && strings.HasPrefix(remoteCmd, "rm -rf") {
+				return exec.Command("false")
+			}
+		}
+		return exec.Command("true")
+	}
+}
+
+func TestExecuteDeleteBackupOnSegments(t *testing.T) {
+	testhelper.SetupTestLogger()
+	tests := []struct {
+		name         string
+		failOnRmRf   bool
+		ignoreErrors bool
+		wantErr      bool
+	}{
+		{
+			name:         "Delete phase error causes error",
+			failOnRmRf:   true,
+			ignoreErrors: false,
+			wantErr:      true,
+		},
+		{
+			name:         "All phases succeed",
+			failOnRmRf:   false,
+			ignoreErrors: false,
+			wantErr:      false,
+		},
+		{
+			name:         "Delete phase error ignored",
+			failOnRmRf:   true,
+			ignoreErrors: true,
+			wantErr:      false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			origExecCommand := execCommand
+			defer func() { execCommand = origExecCommand }()
+			execCommand = fakeExecCommand(tt.failOnRmRf)
+			configs := []gpbckpconfig.SegmentConfig{
+				{ContentID: "0", Hostname: "host1", DataDir: "/data/seg0"},
+				{ContentID: "1", Hostname: "host2", DataDir: "/data/seg1"},
+			}
+			err := executeDeleteBackupOnSegments(
+				"/tmp",
+				"",
+				"20230101010101",
+				"gpseg",
+				true,
+				tt.ignoreErrors,
+				configs,
+				2,
+			)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("\nexecuteDeleteBackupOnSegments() error:\n%v\nwantErr:\n%v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestDeleteBackupDirOnSegments_ClosedChannel reproduces the original bug directly:
+// sending an error to an already-closed channel should panic.
+func TestDeleteBackupDirOnSegments_ClosedChannel(t *testing.T) {
+	testhelper.SetupTestLogger()
+	origExecCommand := execCommand
+	defer func() { execCommand = origExecCommand }()
+	execCommand = func(command string, args ...string) *exec.Cmd {
+		return exec.Command("false")
+	}
+	errCh := make(chan error, 1)
+	close(errCh)
+	defer func() {
+		if r := recover(); r != nil {
+			if msg := fmt.Sprintf("%v", r); !strings.Contains(msg, "send on closed channel") {
+				t.Errorf("unexpected panic: %v", r)
+			}
+		}
+	}()
+	deleteBackupDirOnSegments("/some/path", "host1", "user", errCh)
+}


### PR DESCRIPTION
The function used a single errCh channel shared between the directory existence check phase and the delete phase. After the check phase completed, errCh was closed via sync.Once. When the delete phase encountered an SSH error, deleteBackupDirOnSegments attempted to send to the already-closed channel, causing a panic.

The bug is triggered when SSH succeeds for "test -d" but fails for "rm -rf" (e.g. connection drop). Hard to hit in practice since rm -rf rarely fails, which is why it went unnoticed.

Fix: use separate channels (checkErrCh, deleteErrCh) for each phase.

Each channel is closed with a plain close() after wg.Wait(), which is safe since all goroutines have finished. sync.Once is removed as it is no longer needed.

Tests verify the panic fix for send on closed channel when the delete phase encounters an SSH error.
Tests added in backup_delete_test.go:
*  mocks SSH so "test -d" succeeds and "rm -rf" fails, expects error without panic.
* both phases succeed, no error returned.
* "rm -rf" fails but ignoreErrors=true,  no error propagated.

