### PR TITLE
Bump go version and dependencies.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Run linters
         uses: golangci/golangci-lint-action@v7
         with:
-          version: v2.3.1
+          version: v2.12.2
         env:
           TZ: "Etc/UTC"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,10 +13,10 @@ jobs:
       build_platforms: "linux/amd64,linux/arm64"
       app_name: "gpbackman"
     steps:
-      - name: Set up go 1.24
+      - name: Set up go 1.25
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version: "1.25"
         id: go
       - name: Checkout
         uses: actions/checkout@v4
@@ -163,10 +163,10 @@ jobs:
     env: 
       goreleaser_version: "v2.11.2"
     steps:
-      - name: Set up go 1.24
+      - name: Set up go 1.25
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version: "1.25"
         id: go
 
       - name: Checkout

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG REPO_BUILD_TAG="unknown"
 
-FROM golang:1.24-bookworm AS builder
+FROM golang:1.25-bookworm AS builder
 ARG REPO_BUILD_TAG
 COPY . /build
 WORKDIR /build

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,6 +1,6 @@
 ARG REPO_BUILD_TAG="unknown"
 
-FROM golang:1.25-alpine3.21 AS builder
+FROM golang:1.25-alpine3.23 AS builder
 ARG REPO_BUILD_TAG
 COPY . /build
 WORKDIR /build
@@ -10,7 +10,7 @@ RUN apk add --no-cache --update build-base \
         -ldflags "-X main.version=${REPO_BUILD_TAG}" \
         -o gpbackman gpbackman.go
 
-FROM alpine:3.21
+FROM alpine:3.23
 ARG REPO_BUILD_TAG
 ENV TZ="Etc/UTC" \
     GPBACKMAN_USER="gpbackman" \

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,6 +1,6 @@
 ARG REPO_BUILD_TAG="unknown"
 
-FROM golang:1.24-alpine3.21 AS builder
+FROM golang:1.25-alpine3.21 AS builder
 ARG REPO_BUILD_TAG
 COPY . /build
 WORKDIR /build

--- a/Dockerfile.artifacts
+++ b/Dockerfile.artifacts
@@ -3,7 +3,7 @@ WORKDIR /build
 COPY . /build
 RUN goreleaser release --snapshot --skip=publish --clean
 
-FROM alpine:3.21
+FROM alpine:3.23
 COPY --from=builder /build/dist/ /dist/
 RUN mkdir -p /artifacts && \
     cp /dist/*.tar.gz /artifacts/ && \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/woblerr/gpbackman
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/greenplum-db/gp-common-go-libs v1.0.15

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/woblerr/gpbackman
 go 1.25.0
 
 require (
-	github.com/greenplum-db/gp-common-go-libs v1.0.15
+	github.com/greenplum-db/gp-common-go-libs v1.0.22
 	github.com/greenplum-db/gpbackup v0.0.0-20240215213028-2782cd0fbd9b
 	github.com/jedib0t/go-pretty/v6 v6.6.8
 	github.com/jmoiron/sqlx v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -37,8 +37,8 @@ github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeN
 github.com/google/pprof v0.0.0-20240227163752-401108e1b7e7 h1:y3N7Bm7Y9/CtpiVkw/ZWj6lSlDF3F74SfKwfTCer72Q=
 github.com/google/pprof v0.0.0-20240227163752-401108e1b7e7/go.mod h1:czg5+yv1E0ZGTi6S6vVK1mke0fV+FaUhNGcd6VRS9Ik=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
-github.com/greenplum-db/gp-common-go-libs v1.0.15 h1:a4wELmY1RRQK8he0cqAcuxO4uob0UOfcik7dYjPovts=
-github.com/greenplum-db/gp-common-go-libs v1.0.15/go.mod h1:fuYZO2PgbGH0LMKtldbunHz77XkUFYLILtkfOMAFi4U=
+github.com/greenplum-db/gp-common-go-libs v1.0.22 h1:+dgQBBLRHEZoBHwjU+XHO4oIgVPQoWiIODo/gON9L50=
+github.com/greenplum-db/gp-common-go-libs v1.0.22/go.mod h1:03Vvqi9U/KP7GivSUf4GY2EDjWpfvlnkprU+muFd/pY=
 github.com/greenplum-db/gpbackup v0.0.0-20240215213028-2782cd0fbd9b h1:dIkOvc3EvF0I0pvQrSPznQEala56KHWrKUOAOTsDETQ=
 github.com/greenplum-db/gpbackup v0.0.0-20240215213028-2782cd0fbd9b/go.mod h1:B3gj84ag1BQ6jRJ/baPZ/VCzieZnYomwvQw+DO2e1Sw=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=

--- a/vendor/github.com/greenplum-db/gp-common-go-libs/cluster/cluster.go
+++ b/vendor/github.com/greenplum-db/gp-common-go-libs/cluster/cluster.go
@@ -8,6 +8,8 @@ package cluster
 import (
 	"bufio"
 	"bytes"
+	"context"
+	joinerrs "errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -15,6 +17,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/greenplum-db/gp-common-go-libs/dbconn"
 	"github.com/greenplum-db/gp-common-go-libs/gplog"
@@ -24,7 +27,9 @@ import (
 
 type Executor interface {
 	ExecuteLocalCommand(commandStr string) (string, error)
+	ExecuteLocalCommandWithContext(commandStr string, ctx context.Context) (string, error)
 	ExecuteClusterCommand(scope Scope, commandList []ShellCommand) *RemoteOutput
+	ExecuteClusterCommandWithRetries(scope Scope, commandList []ShellCommand, maxAttempts int, retrySleep time.Duration) *RemoteOutput
 }
 
 // This type only exists to allow us to mock Execute[...]Command functions for testing
@@ -176,6 +181,7 @@ type ShellCommand struct {
 	Stdout        string
 	Stderr        string
 	Error         error
+	RetryError    error
 	Completed     bool
 }
 
@@ -194,26 +200,29 @@ func NewShellCommand(scope Scope, content int, host string, command []string) Sh
  * of a cluster command and to display the results to the user.
  */
 type RemoteOutput struct {
-	Scope          Scope
-	NumErrors      int
-	Commands       []ShellCommand
-	FailedCommands []*ShellCommand
+	Scope           Scope
+	NumErrors       int
+	Commands        []ShellCommand
+	FailedCommands  []ShellCommand
+	RetriedCommands []ShellCommand
 }
 
 func NewRemoteOutput(scope Scope, numErrors int, commands []ShellCommand) *RemoteOutput {
-	failedCommands := make([]*ShellCommand, numErrors)
-	index := 0
-	for i := range commands {
-		if commands[i].Error != nil {
-			failedCommands[index] = &commands[i]
-			index++
+	failedCommands := make([]ShellCommand, 0)
+	retriedCommands := make([]ShellCommand, 0)
+	for _, command := range commands {
+		if command.Error != nil {
+			failedCommands = append(failedCommands, command)
+		} else if command.RetryError != nil {
+			retriedCommands = append(retriedCommands, command)
 		}
 	}
 	return &RemoteOutput{
-		Scope:          scope,
-		NumErrors:      numErrors,
-		Commands:       commands,
-		FailedCommands: failedCommands,
+		Scope:           scope,
+		NumErrors:       numErrors,
+		Commands:        commands,
+		FailedCommands:  failedCommands,
+		RetriedCommands: retriedCommands,
 	}
 }
 
@@ -330,23 +339,59 @@ func (executor *GPDBExecutor) ExecuteLocalCommand(commandStr string) (string, er
 	return string(output), err
 }
 
+func (executor *GPDBExecutor) ExecuteLocalCommandWithContext(commandStr string, ctx context.Context) (string, error) {
+	output, err := exec.CommandContext(ctx, "bash", "-c", commandStr).CombinedOutput()
+	return string(output), err
+}
+
+// Create a new exec.Command object so we can run it again
+func resetCmd(cmd *exec.Cmd) *exec.Cmd {
+	args := cmd.Args
+	return exec.Command(args[0], args[1:]...)
+}
+
+/*
+ * ExecuteClusterCommandWithRetries, but only 1 attempt to keep the previous functionality
+ */
+func (executor *GPDBExecutor) ExecuteClusterCommand(scope Scope, commandList []ShellCommand) *RemoteOutput {
+	return executor.ExecuteClusterCommandWithRetries(scope, commandList, 1, 0)
+}
+
 /*
  * This function just executes all of the commands passed to it in parallel; it
  * doesn't care about the scope of the command except to pass that on to the
  * RemoteOutput after execution.
+ *
+ * It will retry the command up to maxAttempts times
  * TODO: Add batching to prevent bottlenecks when executing in a huge cluster.
  */
-func (executor *GPDBExecutor) ExecuteClusterCommand(scope Scope, commandList []ShellCommand) *RemoteOutput {
+func (executor *GPDBExecutor) ExecuteClusterCommandWithRetries(scope Scope, commandList []ShellCommand, maxAttempts int, retrySleep time.Duration) *RemoteOutput {
 	length := len(commandList)
 	finished := make(chan int)
 	numErrors := 0
 	for i := range commandList {
 		go func(index int) {
+			var (
+				out    []byte
+				err    error
+				stderr bytes.Buffer
+			)
 			command := commandList[index]
-			var stderr bytes.Buffer
-			cmd := command.Command
-			cmd.Stderr = &stderr
-			out, err := cmd.Output()
+			for attempt := 1; attempt <= maxAttempts; attempt++ {
+				stderr.Reset()
+				cmd := resetCmd(command.Command)
+				cmd.Stderr = &stderr
+				out, err = cmd.Output()
+				if err == nil {
+					break
+				} else {
+					newRetryErr := fmt.Errorf("attempt %d: error was %w: %s", attempt, err, stderr.String())
+					command.RetryError = joinerrs.Join(command.RetryError, newRetryErr)
+					if attempt != maxAttempts {
+						time.Sleep(retrySleep)
+					}
+				}
+			}
 			command.Stdout = string(out)
 			command.Stderr = stderr.String()
 			command.Error = err
@@ -375,10 +420,23 @@ func (executor *GPDBExecutor) ExecuteClusterCommand(scope Scope, commandList []S
 func (cluster *Cluster) GenerateAndExecuteCommand(verboseMsg string, scope Scope, generator interface{}) *RemoteOutput {
 	gplog.Verbose(verboseMsg)
 	commandList := cluster.GenerateSSHCommandList(scope, generator)
-	return cluster.ExecuteClusterCommand(scope, commandList)
+	return cluster.ExecuteClusterCommandWithRetries(scope, commandList, 5, 1*time.Second)
 }
 
 func (cluster *Cluster) CheckClusterError(remoteOutput *RemoteOutput, finalErrMsg string, messageFunc interface{}, noFatal ...bool) {
+	for _, retriedCommand := range remoteOutput.RetriedCommands {
+		switch messageFunc.(type) {
+		case func(content int) string:
+			content := retriedCommand.Content
+			host := cluster.GetHostForContent(content)
+			gplog.Debug("Command failed before passing on segment %d on host %s with error:\n%v", content, host, retriedCommand.RetryError)
+		case func(host string) string:
+			host := retriedCommand.Host
+			gplog.Debug("Command failed before passing on host %s with error:\n%v", host, retriedCommand.RetryError)
+		}
+		gplog.Debug("Command was: %s", retriedCommand.CommandString)
+	}
+
 	if remoteOutput.NumErrors == 0 {
 		return
 	}
@@ -388,10 +446,10 @@ func (cluster *Cluster) CheckClusterError(remoteOutput *RemoteOutput, finalErrMs
 		case func(content int) string:
 			content := failedCommand.Content
 			host := cluster.GetHostForContent(content)
-			gplog.Verbose("%s on segment %d on host %s %s", getMessage(content), content, host, errStr)
+			gplog.Custom(gplog.LOGERROR, gplog.LOGVERBOSE, "%s on segment %d on host %s %s", getMessage(content), content, host, errStr)
 		case func(host string) string:
 			host := failedCommand.Host
-			gplog.Verbose("%s on host %s %s", getMessage(host), host, errStr)
+			gplog.Custom(gplog.LOGERROR, gplog.LOGVERBOSE, "%s on host %s %s", getMessage(host), host, errStr)
 		}
 		gplog.Verbose("Command was: %s", failedCommand.CommandString)
 	}
@@ -434,6 +492,9 @@ func getSegmentByRole(segmentList []*SegConfig, role ...string) *SegConfig {
 			return nil
 		}
 		return segmentList[1]
+	}
+	if len(segmentList) == 0 {
+		return nil
 	}
 	return segmentList[0]
 }

--- a/vendor/github.com/greenplum-db/gp-common-go-libs/dbconn/dbconn.go
+++ b/vendor/github.com/greenplum-db/gp-common-go-libs/dbconn/dbconn.go
@@ -352,6 +352,14 @@ func (dbconn *DBConn) Select(destination interface{}, query string, whichConn ..
 	return dbconn.ConnPool[connNum].Select(destination, query)
 }
 
+func (dbconn *DBConn) SelectContext(ctx context.Context, destination interface{}, query string, whichConn ...int) error {
+	connNum := dbconn.ValidateConnNum(whichConn...)
+	if dbconn.Tx[connNum] != nil {
+		return dbconn.Tx[connNum].SelectContext(ctx, destination, query)
+	}
+	return dbconn.ConnPool[connNum].SelectContext(ctx, destination, query)
+}
+
 func (dbconn *DBConn) QueryWithArgs(query string, args ...interface{}) (*sqlx.Rows, error) {
 	if dbconn.Tx[0] != nil {
 		return dbconn.Tx[0].Queryx(query, args...)
@@ -365,6 +373,14 @@ func (dbconn *DBConn) Query(query string, whichConn ...int) (*sqlx.Rows, error) 
 		return dbconn.Tx[connNum].Queryx(query)
 	}
 	return dbconn.ConnPool[connNum].Queryx(query)
+}
+
+func (dbconn *DBConn) QueryContext(ctx context.Context, query string, whichConn ...int) (*sqlx.Rows, error) {
+	connNum := dbconn.ValidateConnNum(whichConn...)
+	if dbconn.Tx[connNum] != nil {
+		return dbconn.Tx[connNum].QueryxContext(ctx, query)
+	}
+	return dbconn.ConnPool[connNum].QueryxContext(ctx, query)
 }
 
 /*

--- a/vendor/github.com/greenplum-db/gp-common-go-libs/gplog/gplog.go
+++ b/vendor/github.com/greenplum-db/gp-common-go-libs/gplog/gplog.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"regexp"
 	"strings"
 	"sync"
 
@@ -59,6 +60,19 @@ const (
 	LOGDEBUG
 )
 
+// ESCAPE - ASCII escape character to start color character sequences
+const ESCAPE = "\x1b"
+
+type Color int
+
+// color codes in the order of their escape character sequences
+const (
+	NONE Color = iota
+	RED
+	GREEN
+	YELLOW
+)
+
 /*
  * Leveled logging output functions using the above log levels are implemented
  * below.  Info(), Verbose(), and Debug() print messages when the log level is
@@ -87,14 +101,16 @@ type LogFileNameFunc func(string, string) string
 type ExitFunc func()
 
 type GpLogger struct {
-	logStdout      *log.Logger
-	logStderr      *log.Logger
-	logFile        *log.Logger
-	logFileName    string
-	shellVerbosity int
-	fileVerbosity  int
-	header         string
-	logPrefixFunc  LogPrefixFunc
+	logStdout          *log.Logger
+	logStderr          *log.Logger
+	logFile            *log.Logger
+	logFileName        string
+	shellVerbosity     int
+	fileVerbosity      int
+	header             string
+	logPrefixFunc      LogPrefixFunc
+	shellLogPrefixFunc LogPrefixFunc
+	colorize           bool
 }
 
 /*
@@ -152,14 +168,16 @@ func NewLogger(stdout io.Writer, stderr io.Writer, logFile io.Writer, logFileNam
 		fileVerbosity = logFileVerbosity[0]
 	}
 	return &GpLogger{
-		logStdout:      log.New(stdout, "", 0),
-		logStderr:      log.New(stderr, "", 0),
-		logFile:        log.New(logFile, "", 0),
-		logFileName:    logFileName,
-		shellVerbosity: shellVerbosity,
-		fileVerbosity:  fileVerbosity,
-		header:         GetHeader(program),
-		logPrefixFunc:  nil,
+		logStdout:          log.New(stdout, "", 0),
+		logStderr:          log.New(stderr, "", 0),
+		logFile:            log.New(logFile, "", 0),
+		logFileName:        logFileName,
+		shellVerbosity:     shellVerbosity,
+		fileVerbosity:      fileVerbosity,
+		header:             GetHeader(program),
+		logPrefixFunc:      nil,
+		shellLogPrefixFunc: nil,
+		colorize:           false,
 	}
 }
 
@@ -177,6 +195,30 @@ func SetLogPrefixFunc(logPrefixFunc func(string) string) {
 	logger.logPrefixFunc = logPrefixFunc
 }
 
+// SetShellLogPrefixFunc registers a function that returns a prefix for messages that get printed to the shell console
+func SetShellLogPrefixFunc(logPrefixFunc func(string) string) {
+	logger.shellLogPrefixFunc = logPrefixFunc
+}
+
+// SetColorize sets the flag defining whether to colorize the output to the shell console.
+// The output to log files is never colorized, even if the flag is set to true.
+// Shell console output colorization depends on the message levels:
+// red      - for CRITICAL (non-panic) and ERROR levels
+// yellow   - for WARNING levels
+// green    - for INFO levels produced via Success function call only
+// no color - for all other levels
+func SetColorize(shouldColorize bool) {
+	logger.colorize = shouldColorize
+}
+
+// GetColorize returns whether the colorization of shell console output has been enabled
+func GetColorize() bool {
+	if logger == nil {
+		return false
+	}
+	return logger.colorize
+}
+
 func SetLogFileNameFunc(fileNameFunc func(string, string) string) {
 	logFileNameFunc = fileNameFunc
 }
@@ -190,11 +232,38 @@ func defaultLogPrefixFunc(level string) string {
 	return fmt.Sprintf("%s %s", logTimestamp, fmt.Sprintf(logger.header, level))
 }
 
+// levelsToPrefix is a regex for determining if the message level will be shown on console
+// by the DefaultShortLogPrefixFunc function
+var levelsToPrefix = regexp.MustCompile(`WARNING|ERROR|CRITICAL`)
+
+// DefaultShortLogPrefixFunc returns a short prefix for messages typically sent to the shell console
+// It does not include the timestamp and other system information that would be found in a log file
+// and only displays the message logging level for WARNING, ERROR, and CRITICAL levels. This function must be
+// explicitly set by the users of the logger by calling SetShellLogPrefixFunc(gplog.DefaultShortLogPrefixFunc)
+func DefaultShortLogPrefixFunc(level string) string {
+	if levelsToPrefix.MatchString(level) {
+		return fmt.Sprintf("%s: ", level)
+	}
+	return ""
+}
+
 func GetLogPrefix(level string) string {
 	if logger.logPrefixFunc != nil {
 		return logger.logPrefixFunc(level)
 	}
 	return defaultLogPrefixFunc(level)
+}
+
+// GetShellLogPrefix returns a prefix to prepend to the message before sending it to the shell console
+// Use this mechanism if it is desired to have different prefixes for messages sent to the console and to the log file.
+// A caller must first set a custom function that will provide a custom prefix by calling SetShellLogPrefixFunc.
+// If the custom function has not been provided, this function returns a prefix produced by the GetLogPrefix function,
+// so that the prefixes for the shell console and the log file will be the same.
+func GetShellLogPrefix(level string) string {
+	if logger.shellLogPrefixFunc != nil {
+		return logger.shellLogPrefixFunc(level)
+	}
+	return GetLogPrefix(level)
 }
 
 func GetLogFilePath() string {
@@ -225,6 +294,20 @@ func SetErrorCode(code int) {
 	errorCode = code
 }
 
+func getVerbosityString(verbosity int) string {
+	switch verbosity {
+	case LOGERROR:
+		return "ERROR"
+	case LOGINFO:
+		return "INFO"
+	case LOGVERBOSE:
+		return "DEBUG"
+	case LOGDEBUG:
+		return "DEBUG"
+	}
+	return ""
+}
+
 /*
  * Log output functions, as described above
  */
@@ -232,14 +315,26 @@ func SetErrorCode(code int) {
 func Info(s string, v ...interface{}) {
 	logMutex.Lock()
 	defer logMutex.Unlock()
-	if logger.fileVerbosity >= LOGINFO || logger.shellVerbosity >= LOGINFO {
+	if logger.fileVerbosity >= LOGINFO {
 		message := GetLogPrefix("INFO") + fmt.Sprintf(s, v...)
-		if logger.fileVerbosity >= LOGINFO {
-			_ = logger.logFile.Output(1, message)
-		}
-		if logger.shellVerbosity >= LOGINFO {
-			_ = logger.logStdout.Output(1, message)
-		}
+		_ = logger.logFile.Output(1, message)
+	}
+	if logger.shellVerbosity >= LOGINFO {
+		message := GetShellLogPrefix("INFO") + fmt.Sprintf(s, v...)
+		_ = logger.logStdout.Output(1, message)
+	}
+}
+
+func Success(s string, v ...interface{}) {
+	logMutex.Lock()
+	defer logMutex.Unlock()
+	if logger.fileVerbosity >= LOGINFO {
+		message := GetLogPrefix("INFO") + fmt.Sprintf(s, v...)
+		_ = logger.logFile.Output(1, message)
+	}
+	if logger.shellVerbosity >= LOGINFO {
+		message := GetShellLogPrefix("INFO") + fmt.Sprintf(s, v...)
+		_ = logger.logStdout.Output(1, Colorize(GREEN, message))
 	}
 }
 
@@ -248,51 +343,51 @@ func Warn(s string, v ...interface{}) {
 	defer logMutex.Unlock()
 	message := GetLogPrefix("WARNING") + fmt.Sprintf(s, v...)
 	_ = logger.logFile.Output(1, message)
-	_ = logger.logStdout.Output(1, message)
+	message = GetShellLogPrefix("WARNING") + fmt.Sprintf(s, v...)
+	_ = logger.logStdout.Output(1, Colorize(YELLOW, message))
 }
 
 func Verbose(s string, v ...interface{}) {
 	logMutex.Lock()
 	defer logMutex.Unlock()
-	if logger.fileVerbosity >= LOGVERBOSE || logger.shellVerbosity >= LOGVERBOSE {
+	if logger.fileVerbosity >= LOGVERBOSE {
 		message := GetLogPrefix("DEBUG") + fmt.Sprintf(s, v...)
-		if logger.fileVerbosity >= LOGVERBOSE {
-			_ = logger.logFile.Output(1, message)
-		}
-		if logger.shellVerbosity >= LOGVERBOSE {
-			_ = logger.logStdout.Output(1, message)
-		}
+		_ = logger.logFile.Output(1, message)
+	}
+	if logger.shellVerbosity >= LOGVERBOSE {
+		message := GetShellLogPrefix("DEBUG") + fmt.Sprintf(s, v...)
+		_ = logger.logStdout.Output(1, message)
 	}
 }
 
 func Debug(s string, v ...interface{}) {
 	logMutex.Lock()
 	defer logMutex.Unlock()
-	if logger.fileVerbosity >= LOGDEBUG || logger.shellVerbosity >= LOGDEBUG {
+	if logger.fileVerbosity >= LOGDEBUG {
 		message := GetLogPrefix("DEBUG") + fmt.Sprintf(s, v...)
-		if logger.fileVerbosity >= LOGDEBUG {
-			_ = logger.logFile.Output(1, message)
-		}
-		if logger.shellVerbosity >= LOGDEBUG {
-			_ = logger.logStdout.Output(1, message)
-		}
+		_ = logger.logFile.Output(1, message)
+	}
+	if logger.shellVerbosity >= LOGDEBUG {
+		message := GetShellLogPrefix("DEBUG") + fmt.Sprintf(s, v...)
+		_ = logger.logStdout.Output(1, message)
 	}
 }
 
 func Error(s string, v ...interface{}) {
 	logMutex.Lock()
 	defer logMutex.Unlock()
-	message := GetLogPrefix("ERROR") + fmt.Sprintf(s, v...)
 	errorCode = 1
+	message := GetLogPrefix("ERROR") + fmt.Sprintf(s, v...)
 	_ = logger.logFile.Output(1, message)
-	_ = logger.logStderr.Output(1, message)
+	message = GetShellLogPrefix("ERROR") + fmt.Sprintf(s, v...)
+	_ = logger.logStderr.Output(1, Colorize(RED, message))
 }
 
 func Fatal(err error, s string, v ...interface{}) {
 	logMutex.Lock()
 	defer logMutex.Unlock()
-	message := GetLogPrefix("CRITICAL")
 	errorCode = 2
+	message := ""
 	stackTraceStr := ""
 	if err != nil {
 		message += fmt.Sprintf("%v", err)
@@ -302,11 +397,36 @@ func Fatal(err error, s string, v ...interface{}) {
 		}
 	}
 	message += strings.TrimSpace(fmt.Sprintf(s, v...))
-	_ = logger.logFile.Output(1, message+stackTraceStr)
+	fullMessage := GetLogPrefix("CRITICAL") + message
+	_ = logger.logFile.Output(1, fullMessage+stackTraceStr)
+	fullMessage = GetShellLogPrefix("CRITICAL") + message
+	// messages for panic are not colorized to allow any recover logic to inspect the actual fullMessage
+	// if the fullMessage needs to be output to the shell console, the caller should colorize it explicitly, if desired
 	if logger.shellVerbosity >= LOGVERBOSE {
-		abort(message + stackTraceStr)
+		abort(fullMessage + stackTraceStr)
 	} else {
-		abort(message)
+		abort(fullMessage)
+	}
+}
+
+/*
+ * The Custom log function allows a caller to set different verbosity thresholds for logging to the shell or logfile
+ */
+
+func Custom(customFileVerbosity int, customShellVerbosity int, s string, v ...interface{}) {
+	logMutex.Lock()
+	defer logMutex.Unlock()
+	var message string
+	if logger.fileVerbosity >= customFileVerbosity {
+		message = GetLogPrefix(getVerbosityString(customFileVerbosity)) + fmt.Sprintf(s, v...)
+		_ = logger.logFile.Output(1, message)
+	}
+	if customShellVerbosity == LOGERROR {
+		message = GetShellLogPrefix("ERROR") + fmt.Sprintf(s, v...)
+		_ = logger.logStderr.Output(1, Colorize(RED, message))
+	} else if logger.shellVerbosity >= customShellVerbosity {
+		message = GetShellLogPrefix(getVerbosityString(customShellVerbosity)) + fmt.Sprintf(s, v...)
+		_ = logger.logStdout.Output(1, message)
 	}
 }
 
@@ -323,10 +443,11 @@ func FatalOnError(err error, output ...string) {
 func FatalWithoutPanic(s string, v ...interface{}) {
 	logMutex.Lock()
 	defer logMutex.Unlock()
-	message := GetLogPrefix("CRITICAL") + fmt.Sprintf(s, v...)
 	errorCode = 2
+	message := GetLogPrefix("CRITICAL") + fmt.Sprintf(s, v...)
 	_ = logger.logFile.Output(1, message)
-	_ = logger.logStderr.Output(1, message)
+	message = GetShellLogPrefix("CRITICAL") + fmt.Sprintf(s, v...)
+	_ = logger.logStderr.Output(1, Colorize(RED, message))
 	exitFunc()
 }
 
@@ -385,4 +506,22 @@ func createLogDirectory(dirname string) {
 
 func defaultExit() {
 	os.Exit(1)
+}
+
+// color returns special characters that should be prepended to a string to make it of a particular color on the console
+func color(c Color) string {
+	if c == NONE {
+		return fmt.Sprintf("%s[%dm", ESCAPE, c)
+	}
+	return fmt.Sprintf("%s[3%dm", ESCAPE, c)
+}
+
+// Colorize wraps a string with special characters so that the string has a provided color when output to the console
+// colorization happens only if the logger flag `colorize` is set to true. The function is exported to allow
+// colorization outside the logging methods, such as when recovering from a `panic` when Fatal messages are logged.
+func Colorize(c Color, text string) string {
+	if logger.colorize {
+		return color(c) + text + color(NONE)
+	}
+	return text
 }

--- a/vendor/github.com/greenplum-db/gp-common-go-libs/operating/operating.go
+++ b/vendor/github.com/greenplum-db/gp-common-go-libs/operating/operating.go
@@ -57,11 +57,13 @@ func OpenFileWrite(name string, flag int, perm os.FileMode) (io.WriteCloser, err
 type SystemFunctions struct {
 	Chmod         func(name string, mode os.FileMode) error
 	CurrentUser   func() (*user.User, error)
+	Exit          func(code int)
 	Getenv        func(key string) string
 	Getpid        func() int
 	Glob          func(pattern string) (matches []string, err error)
 	Hostname      func() (string, error)
 	IsNotExist    func(err error) bool
+	LookupEnv     func(key string) (string, bool)
 	MkdirAll      func(path string, perm os.FileMode) error
 	Now           func() time.Time
 	OpenFileRead  func(name string, flag int, perm os.FileMode) (ReadCloserAt, error)
@@ -80,12 +82,14 @@ func InitializeSystemFunctions() *SystemFunctions {
 	return &SystemFunctions{
 		Chmod:         os.Chmod,
 		CurrentUser:   user.Current,
+		Exit:          os.Exit,
 		Getenv:        os.Getenv,
 		Getpid:        os.Getpid,
 		Glob:          filepath.Glob,
 		Hostname:      os.Hostname,
 		IsNotExist:    os.IsNotExist,
 		MkdirAll:      os.MkdirAll,
+		LookupEnv:     os.LookupEnv,
 		Now:           time.Now,
 		OpenFileRead:  OpenFileRead,
 		OpenFileWrite: OpenFileWrite,

--- a/vendor/github.com/greenplum-db/gp-common-go-libs/testhelper/structs.go
+++ b/vendor/github.com/greenplum-db/gp-common-go-libs/testhelper/structs.go
@@ -5,9 +5,11 @@ package testhelper
  */
 
 import (
+	"context"
 	"github.com/greenplum-db/gp-common-go-libs/cluster"
 	"github.com/greenplum-db/gp-common-go-libs/gplog"
 	"github.com/jmoiron/sqlx"
+	"time"
 )
 
 type TestDriver struct {
@@ -58,6 +60,7 @@ type TestExecutor struct {
 	LocalError    error
 	LocalErrors   []error
 	LocalCommands []string
+	LocalContexts []context.Context
 
 	ClusterOutput   *cluster.RemoteOutput
 	ClusterOutputs  []*cluster.RemoteOutput
@@ -95,7 +98,49 @@ func (executor *TestExecutor) ExecuteLocalCommand(commandStr string) (string, er
 	return executor.LocalOutput, nil
 }
 
+func (executor *TestExecutor) ExecuteLocalCommandWithContext(commandStr string, ctx context.Context) (string, error) {
+	executor.NumExecutions++
+	executor.NumLocalExecutions++
+	executor.LocalCommands = append(executor.LocalCommands, commandStr)
+	executor.LocalContexts = append(executor.LocalContexts, ctx)
+	if (executor.LocalOutputs == nil && executor.LocalErrors != nil) || (executor.LocalOutputs != nil && executor.LocalErrors == nil) {
+		gplog.Fatal(nil, "If one of LocalOutputs or LocalErrors is set, both must be set")
+	} else if executor.LocalOutputs != nil && executor.LocalErrors != nil && len(executor.LocalOutputs) != len(executor.LocalErrors) {
+		gplog.Fatal(nil, "Found %d LocalOutputs and %d LocalErrors, but one output and one error must be set for each call", len(executor.LocalOutputs), len(executor.LocalErrors))
+	}
+	if executor.LocalOutputs != nil {
+		if executor.NumLocalExecutions <= len(executor.LocalOutputs) {
+			return executor.LocalOutputs[executor.NumLocalExecutions-1], executor.LocalErrors[executor.NumLocalExecutions-1]
+		} else if executor.UseLastOutput {
+			return executor.LocalOutputs[len(executor.LocalOutputs)-1], executor.LocalErrors[len(executor.LocalErrors)-1]
+		} else if executor.UseDefaultOutput {
+			return executor.LocalOutput, executor.LocalError
+		}
+		gplog.Fatal(nil, "ExecuteLocalCommandWithContext called %d times, but only %d outputs and errors provided", executor.NumLocalExecutions, len(executor.LocalOutputs))
+	} else if executor.ErrorOnExecNum == 0 || executor.NumLocalExecutions == executor.ErrorOnExecNum {
+		return executor.LocalOutput, executor.LocalError
+	}
+	return executor.LocalOutput, nil
+}
+
 func (executor *TestExecutor) ExecuteClusterCommand(scope cluster.Scope, commandList []cluster.ShellCommand) *cluster.RemoteOutput {
+	executor.NumExecutions++
+	executor.NumClusterExecutions++
+	executor.ClusterCommands = append(executor.ClusterCommands, commandList)
+	if executor.ClusterOutputs != nil {
+		if executor.NumClusterExecutions <= len(executor.ClusterOutputs) {
+			return executor.ClusterOutputs[executor.NumClusterExecutions-1]
+		} else if executor.UseLastOutput {
+			return executor.ClusterOutputs[len(executor.ClusterOutputs)-1]
+		} else if executor.UseDefaultOutput {
+			return executor.ClusterOutput
+		}
+		gplog.Fatal(nil, "ExecuteClusterCommand called %d times, but only %d ClusterOutputs provided", executor.NumClusterExecutions, len(executor.ClusterOutputs))
+	}
+	return executor.ClusterOutput
+}
+
+func (executor *TestExecutor) ExecuteClusterCommandWithRetries(scope cluster.Scope, commandList []cluster.ShellCommand, maxAttempts int, retrySleep time.Duration) *cluster.RemoteOutput {
 	executor.NumExecutions++
 	executor.NumClusterExecutions++
 	executor.ClusterCommands = append(executor.ClusterCommands, commandList)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -14,8 +14,8 @@ github.com/google/go-cmp/cmp/internal/diff
 github.com/google/go-cmp/cmp/internal/flags
 github.com/google/go-cmp/cmp/internal/function
 github.com/google/go-cmp/cmp/internal/value
-# github.com/greenplum-db/gp-common-go-libs v1.0.15
-## explicit; go 1.19
+# github.com/greenplum-db/gp-common-go-libs v1.0.22
+## explicit; go 1.21
 github.com/greenplum-db/gp-common-go-libs/cluster
 github.com/greenplum-db/gp-common-go-libs/dbconn
 github.com/greenplum-db/gp-common-go-libs/gplog


### PR DESCRIPTION
* Bumped go to `1.25`.
* Bumped alpine to `3.23`.
* Bumped gp-common-go-libs to `v1.0.22`.
* Bumped golangci-lint to `v2.12.2`.