### PR TITLE
Add opt-in history db auto-load.

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -63,7 +63,8 @@ For non local backups the following logic are applied:
 
 The gpbackup_history.db file location can be set using the --history-db option.
 Can be specified only once. The full path to the file is required.
-If the --history-db option is not specified, the history database will be searched in the current directory.
+If the --history-db option is not specified, gpbackman uses gpbackup_history.db in the current directory.
+Pass --auto-load-history-db to resolve it from MASTER_DATA_DIRECTORY first, then COORDINATOR_DATA_DIRECTORY.
 
 Usage:
   gpbackman backup-clean [flags]
@@ -79,6 +80,7 @@ Flags:
       --plugin-config string      the full path to plugin config file
 
 Global Flags:
+      --auto-load-history-db       resolve gpbackup_history.db from $MASTER_DATA_DIRECTORY or $COORDINATOR_DATA_DIRECTORY when --history-db is unset
       --history-db string          full path to the gpbackup_history.db file
       --log-file string            full path to log file directory, if not specified, the log file will be created in the $HOME/gpAdminLogs directory
       --log-level-console string   level for console logging (error, info, debug, verbose) (default "info")
@@ -188,7 +190,8 @@ For non local backups the following logic are applied:
 
 The gpbackup_history.db file location can be set using the --history-db option.
 Can be specified only once. The full path to the file is required.
-If the --history-db option is not specified, the history database will be searched in the current directory.
+If the --history-db option is not specified, gpbackman uses gpbackup_history.db in the current directory.
+Pass --auto-load-history-db to resolve it from MASTER_DATA_DIRECTORY first, then COORDINATOR_DATA_DIRECTORY.
 
 Usage:
   gpbackman backup-delete [flags]
@@ -204,6 +207,7 @@ Flags:
       --timestamp stringArray    the backup timestamp for deleting, could be specified multiple times
 
 Global Flags:
+      --auto-load-history-db       resolve gpbackup_history.db from $MASTER_DATA_DIRECTORY or $COORDINATOR_DATA_DIRECTORY when --history-db is unset
       --history-db string          full path to the gpbackup_history.db file
       --log-file string            full path to log file directory, if not specified, the log file will be created in the $HOME/gpAdminLogs directory
       --log-level-console string   level for console logging (error, info, debug, verbose) (default "info")
@@ -304,7 +308,8 @@ To display the "object filtering details" column for all backups without using -
 
 The gpbackup_history.db file location can be set using the --history-db option.
 Can be specified only once. The full path to the file is required.
-If the --history-db option is not specified, the history database will be searched in the current directory.
+If the --history-db option is not specified, gpbackman uses gpbackup_history.db in the current directory.
+Pass --auto-load-history-db to resolve it from MASTER_DATA_DIRECTORY first, then COORDINATOR_DATA_DIRECTORY.
 
 Usage:
   gpbackman backup-info [flags]
@@ -321,6 +326,7 @@ Flags:
       --type string        backup type filter (full, incremental, data-only, metadata-only)
 
 Global Flags:
+      --auto-load-history-db       resolve gpbackup_history.db from $MASTER_DATA_DIRECTORY or $COORDINATOR_DATA_DIRECTORY when --history-db is unset
       --history-db string          full path to the gpbackup_history.db file
       --log-file string            full path to log file directory, if not specified, the log file will be created in the $HOME/gpAdminLogs directory
       --log-level-console string   level for console logging (error, info, debug, verbose) (default "info")
@@ -516,7 +522,8 @@ Only --older-than-days or --before-timestamp option must be specified, not both.
 
 The gpbackup_history.db file location can be set using the --history-db option.
 Can be specified only once. The full path to the file is required.
-If the --history-db option is not specified, the history database will be searched in the current directory.
+If the --history-db option is not specified, gpbackman uses gpbackup_history.db in the current directory.
+Pass --auto-load-history-db to resolve it from MASTER_DATA_DIRECTORY first, then COORDINATOR_DATA_DIRECTORY.
 
 Usage:
   gpbackman history-clean [flags]
@@ -527,6 +534,7 @@ Flags:
       --older-than-days uint      delete information about backups older than the given number of days
 
 Global Flags:
+      --auto-load-history-db       resolve gpbackup_history.db from $MASTER_DATA_DIRECTORY or $COORDINATOR_DATA_DIRECTORY when --history-db is unset
       --history-db string          full path to the gpbackup_history.db file
       --log-file string            full path to log file directory, if not specified, the log file will be created in the $HOME/gpAdminLogs directory
       --log-level-console string   level for console logging (error, info, debug, verbose) (default "info")
@@ -581,7 +589,8 @@ Can be specified only once. The full path to the file is required.
 The gpbackup_history.yaml file location can be set using the --history-file option.
 Can be specified multiple times. The full path to the file is required.
 
-If the --history-db option is not specified, the history database will be searched in the current directory.
+If the --history-db option is not specified, gpbackman uses gpbackup_history.db in the current directory.
+Pass --auto-load-history-db to resolve it from MASTER_DATA_DIRECTORY first, then COORDINATOR_DATA_DIRECTORY.
 
 Usage:
   gpbackman history-migrate [flags]
@@ -591,6 +600,7 @@ Flags:
       --history-file stringArray   full path to the gpbackup_history.yaml file, could be specified multiple times
 
 Global Flags:
+      --auto-load-history-db       resolve gpbackup_history.db from $MASTER_DATA_DIRECTORY or $COORDINATOR_DATA_DIRECTORY when --history-db is unset
       --history-db string          full path to the gpbackup_history.db file
       --log-file string            full path to log file directory, if not specified, the log file will be created in the $HOME/gpAdminLogs directory
       --log-level-console string   level for console logging (error, info, debug, verbose) (default "info")
@@ -658,7 +668,8 @@ It is not necessary to use the --plugin-report-file-path flag for the following 
 
 The gpbackup_history.db file location can be set using the --history-db option.
 Can be specified only once. The full path to the file is required.
-If the --history-db option is not specified, the history database will be searched in the current directory.
+If the --history-db option is not specified, gpbackman uses gpbackup_history.db in the current directory.
+Pass --auto-load-history-db to resolve it from MASTER_DATA_DIRECTORY first, then COORDINATOR_DATA_DIRECTORY.
 
 Usage:
   gpbackman report-info [flags]
@@ -671,6 +682,7 @@ Flags:
       --timestamp string                 the backup timestamp for report displaying
 
 Global Flags:
+      --auto-load-history-db       resolve gpbackup_history.db from $MASTER_DATA_DIRECTORY or $COORDINATOR_DATA_DIRECTORY when --history-db is unset
       --history-db string          full path to the gpbackup_history.db file
       --log-file string            full path to log file directory, if not specified, the log file will be created in the $HOME/gpAdminLogs directory
       --log-level-console string   level for console logging (error, info, debug, verbose) (default "info")

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Available Commands:
 
 Flags:
   -h, --help                       help for gpbackman
+      --auto-load-history-db       resolve gpbackup_history.db from $MASTER_DATA_DIRECTORY or $COORDINATOR_DATA_DIRECTORY when --history-db is unset
       --history-db string          full path to the gpbackup_history.db file
       --log-file string            full path to log file directory, if not specified, the log file will be created in the $HOME/gpAdminLogs directory
       --log-level-console string   level for console logging (error, info, debug, verbose) (default "info")

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,29 @@
+# Third-party Notices
+
+This project includes code and documentation changes adapted from Apache
+Cloudberry Backup.
+
+## Apache Cloudberry Backup
+
+Source repository: https://github.com/apache/cloudberry-backup
+
+Source pull request: https://github.com/apache/cloudberry-backup/pull/97
+
+License: Apache License, Version 2.0
+
+Copyright: The Apache Software Foundation
+
+The following parts of this project contain changes adapted from the upstream
+Apache Cloudberry Backup gpbackman implementation:
+
+- history database path resolution for `--auto-load-history-db`
+- history database opening behavior with `mode=rw`
+- user-facing history database error handling
+- related command help text, documentation, and tests
+
+The imported changes were modified to fit this project's structure, naming,
+message handling, and Greenplum compatibility requirements.
+
+A copy of the Apache License, Version 2.0 is provided in:
+
+`third_party_licenses/APACHE-2.0.txt`

--- a/cmd/backup_clean.go
+++ b/cmd/backup_clean.go
@@ -57,7 +57,8 @@ For non local backups the following logic are applied:
 
 The gpbackup_history.db file location can be set using the --history-db option.
 Can be specified only once. The full path to the file is required.
-If the --history-db option is not specified, the history database will be searched in the current directory.`,
+If the --history-db option is not specified, gpbackman uses gpbackup_history.db in the current directory.
+Pass --auto-load-history-db to resolve it from MASTER_DATA_DIRECTORY first, then COORDINATOR_DATA_DIRECTORY.`,
 	Args: cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		doRootFlagValidation(cmd.Flags(), checkFileExistsConst)
@@ -185,7 +186,7 @@ func doCleanBackup() {
 }
 
 func cleanBackup() error {
-	hDB, err := gpbckpconfig.OpenHistoryDB(getHistoryDBPath(rootHistoryDB))
+	hDB, err := gpbckpconfig.OpenHistoryDB(getHistoryDBPath(rootHistoryDB, rootAutoLoadHistoryDB))
 	if err != nil {
 		gplog.Error("%s", textmsg.ErrorTextUnableActionHistoryDB("open", err))
 		return err

--- a/cmd/backup_delete.go
+++ b/cmd/backup_delete.go
@@ -63,7 +63,8 @@ For non local backups the following logic are applied:
 
 The gpbackup_history.db file location can be set using the --history-db option.
 Can be specified only once. The full path to the file is required.
-If the --history-db option is not specified, the history database will be searched in the current directory.`,
+If the --history-db option is not specified, gpbackman uses gpbackup_history.db in the current directory.
+Pass --auto-load-history-db to resolve it from MASTER_DATA_DIRECTORY first, then COORDINATOR_DATA_DIRECTORY.`,
 	Args: cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		doRootFlagValidation(cmd.Flags(), checkFileExistsConst)
@@ -184,7 +185,7 @@ func doDeleteBackup() {
 }
 
 func deleteBackup() error {
-	hDB, err := gpbckpconfig.OpenHistoryDB(getHistoryDBPath(rootHistoryDB))
+	hDB, err := gpbckpconfig.OpenHistoryDB(getHistoryDBPath(rootHistoryDB, rootAutoLoadHistoryDB))
 	if err != nil {
 		gplog.Error("%s", textmsg.ErrorTextUnableActionHistoryDB("open", err))
 		return err

--- a/cmd/backup_info.go
+++ b/cmd/backup_info.go
@@ -77,7 +77,8 @@ To display the "object filtering details" column for all backups without using -
 
 The gpbackup_history.db file location can be set using the --history-db option.
 Can be specified only once. The full path to the file is required.
-If the --history-db option is not specified, the history database will be searched in the current directory.`,
+If the --history-db option is not specified, gpbackman uses gpbackup_history.db in the current directory.
+Pass --auto-load-history-db to resolve it from MASTER_DATA_DIRECTORY first, then COORDINATOR_DATA_DIRECTORY.`,
 	Args: cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		doRootFlagValidation(cmd.Flags(), checkFileExistsConst)
@@ -205,7 +206,7 @@ func backupInfo() error {
 		ShowDetails:      backupInfoShowDetails,
 	}
 	initTable(t, opts.ShowDetails)
-	hDB, err := gpbckpconfig.OpenHistoryDB(getHistoryDBPath(rootHistoryDB))
+	hDB, err := gpbckpconfig.OpenHistoryDB(getHistoryDBPath(rootHistoryDB, rootAutoLoadHistoryDB))
 	if err != nil {
 		gplog.Error("%s", textmsg.ErrorTextUnableActionHistoryDB("open", err))
 		return err

--- a/cmd/constants.go
+++ b/cmd/constants.go
@@ -19,6 +19,7 @@ const (
 
 	// Flags.
 	historyDBFlagName            = "history-db"
+	autoLoadHistoryDBFlagName    = "auto-load-history-db"
 	historyFilesFlagName         = "history-file"
 	logFileFlagName              = "log-file"
 	logLevelConsoleFlagName      = "log-level-console"
@@ -57,4 +58,10 @@ var (
 	beforeTimestamp string
 	// Timestamp to delete all backups after.
 	afterTimestamp string
+
+	// GP6 exports MASTER_DATA_DIRECTORY, while GP7 exports COORDINATOR_DATA_DIRECTORY.
+	historyDBEnvVars = []string{
+		"MASTER_DATA_DIRECTORY",
+		"COORDINATOR_DATA_DIRECTORY",
+	}
 )

--- a/cmd/history_clean.go
+++ b/cmd/history_clean.go
@@ -30,7 +30,8 @@ Only --older-than-days or --before-timestamp option must be specified, not both.
 
 The gpbackup_history.db file location can be set using the --history-db option.
 Can be specified only once. The full path to the file is required.
-If the --history-db option is not specified, the history database will be searched in the current directory.`,
+If the --history-db option is not specified, gpbackman uses gpbackup_history.db in the current directory.
+Pass --auto-load-history-db to resolve it from MASTER_DATA_DIRECTORY first, then COORDINATOR_DATA_DIRECTORY.`,
 	Args: cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		doRootFlagValidation(cmd.Flags(), checkFileExistsConst)
@@ -86,7 +87,7 @@ func doCleanHistory() {
 }
 
 func cleanHistory() error {
-	hDB, err := gpbckpconfig.OpenHistoryDB(getHistoryDBPath(rootHistoryDB))
+	hDB, err := gpbckpconfig.OpenHistoryDB(getHistoryDBPath(rootHistoryDB, rootAutoLoadHistoryDB))
 	if err != nil {
 		gplog.Error("%s", textmsg.ErrorTextUnableActionHistoryDB("open", err))
 		return err

--- a/cmd/history_migrate.go
+++ b/cmd/history_migrate.go
@@ -26,7 +26,8 @@ Can be specified only once. The full path to the file is required.
 The gpbackup_history.yaml file location can be set using the --history-file option.
 Can be specified multiple times. The full path to the file is required.
 
-If the --history-db option is not specified, the history database will be searched in the current directory.`,
+If the --history-db option is not specified, gpbackman uses gpbackup_history.db in the current directory.
+Pass --auto-load-history-db to resolve it from MASTER_DATA_DIRECTORY first, then COORDINATOR_DATA_DIRECTORY.`,
 	Args: cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		// No need to check historyDB existence.
@@ -73,7 +74,7 @@ func doMigrateHistory() {
 }
 
 func migrateHistory() error {
-	hDB, err := history.InitializeHistoryDatabase(getHistoryDBPath(rootHistoryDB))
+	hDB, err := history.InitializeHistoryDatabase(getHistoryDBPath(rootHistoryDB, rootAutoLoadHistoryDB))
 	if err != nil {
 		gplog.Error("%s", textmsg.ErrorTextUnableInitHistoryDB(err))
 		return err

--- a/cmd/report_info.go
+++ b/cmd/report_info.go
@@ -57,7 +57,8 @@ It is not necessary to use the --plugin-report-file-path flag for the following 
 
 The gpbackup_history.db file location can be set using the --history-db option.
 Can be specified only once. The full path to the file is required.
-If the --history-db option is not specified, the history database will be searched in the current directory.`,
+If the --history-db option is not specified, gpbackman uses gpbackup_history.db in the current directory.
+Pass --auto-load-history-db to resolve it from MASTER_DATA_DIRECTORY first, then COORDINATOR_DATA_DIRECTORY.`,
 	Args: cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		doRootFlagValidation(cmd.Flags(), checkFileExistsConst)
@@ -153,7 +154,7 @@ func doReportInfo() {
 }
 
 func reportInfo() error {
-	hDB, err := gpbckpconfig.OpenHistoryDB(getHistoryDBPath(rootHistoryDB))
+	hDB, err := gpbckpconfig.OpenHistoryDB(getHistoryDBPath(rootHistoryDB, rootAutoLoadHistoryDB))
 	if err != nil {
 		gplog.Error("%s", textmsg.ErrorTextUnableActionHistoryDB("open", err))
 		return err
@@ -208,7 +209,7 @@ func reportInfoPluginFunc(backupData gpbckpconfig.BackupConfig, pluginConfigPath
 			gplog.Error("%s", textmsg.ErrorTextUnableGetBackupPath("report", backupData.Timestamp, err))
 			return err
 		}
-			gplog.Debug("%s", textmsg.InfoTextCommandExecution(pluginConfig.ExecutablePath, restoreDataPluginCommand, pluginConfigPath, reportFile))
+		gplog.Debug("%s", textmsg.InfoTextCommandExecution(pluginConfig.ExecutablePath, restoreDataPluginCommand, pluginConfigPath, reportFile))
 		stdout, stderr, err := execReportInfo(pluginConfig.ExecutablePath, restoreDataPluginCommand, pluginConfigPath, reportFile)
 		if stderr != "" {
 			gplog.Error("%s", stderr)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,10 +12,11 @@ import (
 
 // Flags for the gpbackman command (rootCmd)
 var (
-	rootHistoryDB       string
-	rootLogFile         string
-	rootLogLevelConsole string
-	rootLogLevelFile    string
+	rootHistoryDB         string
+	rootAutoLoadHistoryDB bool
+	rootLogFile           string
+	rootLogLevelConsole   string
+	rootLogLevelFile      string
 )
 
 var rootCmd = &cobra.Command{
@@ -30,6 +31,12 @@ func init() {
 		historyDBFlagName,
 		"",
 		"full path to the gpbackup_history.db file",
+	)
+	rootCmd.PersistentFlags().BoolVar(
+		&rootAutoLoadHistoryDB,
+		autoLoadHistoryDBFlagName,
+		false,
+		"resolve gpbackup_history.db from $MASTER_DATA_DIRECTORY or $COORDINATOR_DATA_DIRECTORY when --history-db is unset",
 	)
 	rootCmd.PersistentFlags().StringVar(
 		&rootLogFile,
@@ -68,6 +75,12 @@ func getVersion() string {
 // These flag checks are applied for all commands:
 func doRootFlagValidation(flags *pflag.FlagSet, checkFileExists bool) {
 	var err error
+	// Check that history-db and auto-load-history-db flags are not used together.
+	err = checkCompatibleFlags(flags, historyDBFlagName, autoLoadHistoryDBFlagName)
+	if err != nil {
+		gplog.Error("%s", textmsg.ErrorTextUnableCompatibleFlags(err, historyDBFlagName, autoLoadHistoryDBFlagName))
+		execOSExit(exitErrorCode)
+	}
 	// If history-db flag is specified and full path.
 	// The existence of the file is checked by condition from each specific command.
 	// Not all commands (see history-migrate command, report-info command flags) require a history db file to exist.

--- a/cmd/wrappers.go
+++ b/cmd/wrappers.go
@@ -68,7 +68,9 @@ func getHistoryDBPath(historyDBPath string, autoLoadHistoryDB bool) string {
 	if autoLoadHistoryDB {
 		for _, envVar := range historyDBEnvVars {
 			if dataDir := os.Getenv(envVar); dataDir != "" {
-				return filepath.Join(dataDir, historyDBNameConst)
+				historyDBPath := filepath.Join(dataDir, historyDBNameConst)
+				gplog.Debug("History db path resolved from %s: %s", envVar, historyDBPath)
+				return historyDBPath
 			}
 		}
 	}

--- a/cmd/wrappers.go
+++ b/cmd/wrappers.go
@@ -68,9 +68,9 @@ func getHistoryDBPath(historyDBPath string, autoLoadHistoryDB bool) string {
 	if autoLoadHistoryDB {
 		for _, envVar := range historyDBEnvVars {
 			if dataDir := os.Getenv(envVar); dataDir != "" {
-				historyDBPath := filepath.Join(dataDir, historyDBNameConst)
-				gplog.Debug("History db path resolved from %s: %s", envVar, historyDBPath)
-				return historyDBPath
+				resolvedHistoryDBPath := filepath.Join(dataDir, historyDBNameConst)
+				gplog.Debug("History db path resolved from %s: %s", envVar, resolvedHistoryDBPath)
+				return resolvedHistoryDBPath
 			}
 		}
 	}

--- a/cmd/wrappers.go
+++ b/cmd/wrappers.go
@@ -61,12 +61,18 @@ func setLogLevelFile(level string) error {
 	return nil
 }
 
-func getHistoryDBPath(historyDBPath string) string {
-	var historyDBName = historyDBNameConst
+func getHistoryDBPath(historyDBPath string, autoLoadHistoryDB bool) string {
 	if historyDBPath != "" {
 		return historyDBPath
 	}
-	return historyDBName
+	if autoLoadHistoryDB {
+		for _, envVar := range historyDBEnvVars {
+			if dataDir := os.Getenv(envVar); dataDir != "" {
+				return filepath.Join(dataDir, historyDBNameConst)
+			}
+		}
+	}
+	return historyDBNameConst
 }
 
 func getHistoryFilePath(historyFilePath string) string {

--- a/cmd/wrappers_test.go
+++ b/cmd/wrappers_test.go
@@ -1,9 +1,11 @@
 package cmd
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -32,37 +34,94 @@ func TestGetHistoryFilePath(t *testing.T) {
 
 func TestGetHistoryDBPath(t *testing.T) {
 	tests := []struct {
-		name            string
-		historyFilePath string
-		want            string
+		name               string
+		historyDBPath      string
+		autoLoadHistoryDB  bool
+		masterDataDir      string
+		coordinatorDataDir string
+		want               string
 	}{
-		{"Empty Path", "", historyDBNameConst},
-		{"Non Empty Path", "path/to/" + historyDBNameConst, "path/to/" + historyDBNameConst},
+		{
+			name:          "Empty Path",
+			historyDBPath: "",
+			want:          historyDBNameConst,
+		},
+		{
+			name:          "Non Empty Path",
+			historyDBPath: "path/to/" + historyDBNameConst,
+			want:          "path/to/" + historyDBNameConst,
+		},
+		{
+			name:               "Env Vars Ignored Without Auto Load",
+			autoLoadHistoryDB:  false,
+			masterDataDir:      "/master/data",
+			coordinatorDataDir: "/coordinator/data",
+			want:               historyDBNameConst,
+		},
+		{
+			name:              "Master Data Directory",
+			autoLoadHistoryDB: true,
+			masterDataDir:     "/master/data",
+			want:              filepath.Join("/master/data", historyDBNameConst),
+		},
+		{
+			name:               "Coordinator Data Directory",
+			autoLoadHistoryDB:  true,
+			coordinatorDataDir: "/coordinator/data",
+			want:               filepath.Join("/coordinator/data", historyDBNameConst),
+		},
+		{
+			name:               "Master Data Directory Has Priority",
+			autoLoadHistoryDB:  true,
+			masterDataDir:      "/master/data",
+			coordinatorDataDir: "/coordinator/data",
+			want:               filepath.Join("/master/data", historyDBNameConst),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := getHistoryDBPath(tt.historyFilePath); got != tt.want {
+			t.Setenv("MASTER_DATA_DIRECTORY", tt.masterDataDir)
+			t.Setenv("COORDINATOR_DATA_DIRECTORY", tt.coordinatorDataDir)
+			if got := getHistoryDBPath(tt.historyDBPath, tt.autoLoadHistoryDB); got != tt.want {
 				t.Errorf("\nVariables do not match:\n%v\nwant:\n%v", got, tt.want)
 			}
 		})
 	}
 }
 
-func TestIsBackupActive(t *testing.T) {
-	tests := []struct {
-		name            string
-		historyFilePath string
-		want            string
-	}{
-		{"Empty Path", "", historyDBNameConst},
-		{"Non Empty Path", "path/to/" + historyDBNameConst, "path/to/" + historyDBNameConst},
+func TestRootAutoLoadHistoryDBFlag(t *testing.T) {
+	flag := rootCmd.PersistentFlags().Lookup(autoLoadHistoryDBFlagName)
+	if flag == nil {
+		t.Fatalf("Expected %s flag to be registered", autoLoadHistoryDBFlagName)
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := getHistoryDBPath(tt.historyFilePath); got != tt.want {
-				t.Errorf("\nVariables do not match:\n%v\nwant:\n%v", got, tt.want)
-			}
-		})
+	if flag.DefValue != "false" {
+		t.Errorf("\nDefault value does not match:\n%v\nwant:\n%v", flag.DefValue, "false")
+	}
+	if !strings.Contains(flag.Usage, "MASTER_DATA_DIRECTORY") ||
+		!strings.Contains(flag.Usage, "COORDINATOR_DATA_DIRECTORY") {
+		t.Errorf("Flag usage does not mention both data directory environment variables: %s", flag.Usage)
+	}
+}
+
+func TestRootHelpIncludesAutoLoadHistoryDBFlag(t *testing.T) {
+	var output bytes.Buffer
+	rootCmd.SetOut(&output)
+	rootCmd.SetErr(&output)
+	defer rootCmd.SetOut(os.Stdout)
+	defer rootCmd.SetErr(os.Stderr)
+
+	if err := rootCmd.Help(); err != nil {
+		t.Fatalf("Expected root help to render, got: %v", err)
+	}
+	helpText := output.String()
+	for _, value := range []string{
+		"--auto-load-history-db",
+		"MASTER_DATA_DIRECTORY",
+		"COORDINATOR_DATA_DIRECTORY",
+	} {
+		if !strings.Contains(helpText, value) {
+			t.Errorf("Expected help output to contain %q, got:\n%s", value, helpText)
+		}
 	}
 }
 
@@ -165,6 +224,52 @@ func TestCheckCompatibleFlags(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDoRootFlagValidationRejectsHistoryDBWithAutoLoadHistoryDB(t *testing.T) {
+	testhelper.SetupTestLogger()
+
+	oldExecOSExit := execOSExit
+	oldRootHistoryDB := rootHistoryDB
+	defer func() {
+		execOSExit = oldExecOSExit
+		rootHistoryDB = oldRootHistoryDB
+	}()
+
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	flags.String(historyDBFlagName, "", "")
+	flags.Bool(autoLoadHistoryDBFlagName, false, "")
+
+	rootHistoryDB = "/tmp/gpbackup_history.db"
+	if err := flags.Set(historyDBFlagName, rootHistoryDB); err != nil {
+		t.Fatalf("Failed to set %s flag: %v", historyDBFlagName, err)
+	}
+	if err := flags.Set(autoLoadHistoryDBFlagName, "true"); err != nil {
+		t.Fatalf("Failed to set %s flag: %v", autoLoadHistoryDBFlagName, err)
+	}
+
+	type exitPanic struct {
+		code int
+	}
+	execOSExit = func(code int) {
+		panic(exitPanic{code: code})
+	}
+
+	defer func() {
+		value := recover()
+		if value == nil {
+			t.Fatalf("Expected doRootFlagValidation to exit")
+		}
+		exit, ok := value.(exitPanic)
+		if !ok {
+			panic(value)
+		}
+		if exit.code != exitErrorCode {
+			t.Fatalf("Unexpected exit code:\n%v\nwant:\n%v", exit.code, exitErrorCode)
+		}
+	}()
+
+	doRootFlagValidation(flags, false)
 }
 
 func TestCheckBackupCanBeUsed(t *testing.T) {

--- a/cmd/wrappers_test.go
+++ b/cmd/wrappers_test.go
@@ -33,6 +33,8 @@ func TestGetHistoryFilePath(t *testing.T) {
 }
 
 func TestGetHistoryDBPath(t *testing.T) {
+	testhelper.SetupTestLogger()
+
 	tests := []struct {
 		name               string
 		historyDBPath      string

--- a/cmd/wrappers_test.go
+++ b/cmd/wrappers_test.go
@@ -61,6 +61,11 @@ func TestGetHistoryDBPath(t *testing.T) {
 			want:               historyDBNameConst,
 		},
 		{
+			name:              "Auto Load Without Env Vars",
+			autoLoadHistoryDB: true,
+			want:              historyDBNameConst,
+		},
+		{
 			name:              "Master Data Directory",
 			autoLoadHistoryDB: true,
 			masterDataDir:     "/master/data",

--- a/e2e_tests/scripts/run_tests/run_backup-info.sh
+++ b/e2e_tests/scripts/run_tests/run_backup-info.sh
@@ -103,6 +103,32 @@ test_full_local_include_table_details() {
     fi
 }
 
+# Test 11: Count all backups using --auto-load-history-db and MASTER_DATA_DIRECTORY
+test_count_all_backups_auto_load_master() {
+    local want=12
+    local got=$(
+        (
+            export MASTER_DATA_DIRECTORY="${DATA_DIR}"
+            unset COORDINATOR_DATA_DIRECTORY
+            get_backup_info total_backups_auto_load_master --auto-load-history-db
+        ) | grep -E "${TIMESTAMP_GREP_PATTERN}" | wc -l
+    )
+    assert_equals "${want}" "${got}"
+}
+
+# Test 12: Count all backups using --auto-load-history-db and COORDINATOR_DATA_DIRECTORY
+test_count_all_backups_auto_load_coordinator() {
+    local want=12
+    local got=$(
+        (
+            unset MASTER_DATA_DIRECTORY
+            export COORDINATOR_DATA_DIRECTORY="${DATA_DIR}"
+            get_backup_info total_backups_auto_load_coordinator --auto-load-history-db
+        ) | grep -E "${TIMESTAMP_GREP_PATTERN}" | wc -l
+    )
+    assert_equals "${want}" "${got}"
+}
+
 run_test "${COMMAND}" 1 test_count_all_backups
 run_test "${COMMAND}" 2 test_count_full_backups
 run_test "${COMMAND}" 3 test_count_incremental_backups
@@ -113,5 +139,7 @@ run_test "${COMMAND}" 7 test_count_exclude_schema_incremental_backups
 run_test "${COMMAND}" 8 test_backup_chain_include_tables
 run_test "${COMMAND}" 9 test_backup_chain_incremental_exclude
 run_test "${COMMAND}" 10 test_full_local_include_table_details
+run_test "${COMMAND}" 11 test_count_all_backups_auto_load_master
+run_test "${COMMAND}" 12 test_count_all_backups_auto_load_coordinator
 
 log_all_tests_passed "${COMMAND}"

--- a/e2e_tests/scripts/run_tests/run_history-migrate.sh
+++ b/e2e_tests/scripts/run_tests/run_history-migrate.sh
@@ -7,6 +7,8 @@ set -Eeuo pipefail
 # 3) Duplicate migration into the same DB -> must fail with UNIQUE constraint.
 # 4) Migrate all YAML files into a fresh empty DB in /tmp -> expect 14 backups total.
 # 5) Migrate all YAML files into an existing DB (excluding already migrated full_local) -> expect 12 base + 14 = 26 total; duplicates skipped.
+# 6) Migrate gpbackup_history_full_local.yaml into an empty DB resolved from MASTER_DATA_DIRECTORY -> expect 2 backups.
+# 7) Migrate gpbackup_history_full_local.yaml into an empty DB resolved from COORDINATOR_DATA_DIRECTORY -> expect 2 backups.
 
 source "$(dirname "${BASH_SOURCE[0]}")/common_functions.sh"
 
@@ -99,10 +101,44 @@ test_migrate_all_into_existing_db(){
     assert_equals "${want}" "${got}"
 }
 
+# Test 6: Single file into empty DB resolved by --auto-load-history-db and MASTER_DATA_DIRECTORY
+# Expect 2 backups from file
+test_migrate_single_auto_load_master_into_empty_db(){
+    local workdir=$(prepare_workdir test6)
+    cp "${SRC_DIR}/${TEST_FILE_FULL_LOCAL}" "${workdir}/"
+    (
+        export MASTER_DATA_DIRECTORY="${workdir}"
+        unset COORDINATOR_DATA_DIRECTORY
+        run_command "single_auto_load_master_into_empty_db" --history-file "${workdir}/${TEST_FILE_FULL_LOCAL}" --auto-load-history-db
+    )
+    local db="${workdir}/gpbackup_history.db"
+    local want=2
+    local got=$(get_backup_info total_full_backups --history-db "${db}" | grep -E "${TIMESTAMP_GREP_PATTERN}" | wc -l)
+    assert_equals "${want}" "${got}"
+}
+
+# Test 7: Single file into empty DB resolved by --auto-load-history-db and COORDINATOR_DATA_DIRECTORY
+# Expect 2 backups from file
+test_migrate_single_auto_load_coordinator_into_empty_db(){
+    local workdir=$(prepare_workdir test7)
+    cp "${SRC_DIR}/${TEST_FILE_FULL_LOCAL}" "${workdir}/"
+    (
+        unset MASTER_DATA_DIRECTORY
+        export COORDINATOR_DATA_DIRECTORY="${workdir}"
+        run_command "single_auto_load_coordinator_into_empty_db" --history-file "${workdir}/${TEST_FILE_FULL_LOCAL}" --auto-load-history-db
+    )
+    local db="${workdir}/gpbackup_history.db"
+    local want=2
+    local got=$(get_backup_info total_full_backups --history-db "${db}" | grep -E "${TIMESTAMP_GREP_PATTERN}" | wc -l)
+    assert_equals "${want}" "${got}"
+}
+
 run_test "${COMMAND}" 1 test_migrate_single_into_empty_db
 run_test "${COMMAND}" 2 test_migrate_single_into_existing_db
 run_test "${COMMAND}" 3 test_migrate_duplicate_into_existing_db_fail
 run_test "${COMMAND}" 4 test_migrate_all_into_empty_db
 run_test "${COMMAND}" 5 test_migrate_all_into_existing_db
+run_test "${COMMAND}" 6 test_migrate_single_auto_load_master_into_empty_db
+run_test "${COMMAND}" 7 test_migrate_single_auto_load_coordinator_into_empty_db
 
 log_all_tests_passed "${COMMAND}"

--- a/gpbckpconfig/utils_db.go
+++ b/gpbckpconfig/utils_db.go
@@ -2,19 +2,38 @@ package gpbckpconfig
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/greenplum-db/gpbackup/history"
+	"github.com/woblerr/gpbackman/textmsg"
 )
 
-// OpenHistoryDB Opens the history backup database.
+// OpenHistoryDB opens an existing gpbackup_history.db SQLite database.
 func OpenHistoryDB(historyDBPath string) (*sql.DB, error) {
-	db, err := sql.Open("sqlite3", historyDBPath)
+	if _, err := os.Stat(historyDBPath); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, textmsg.ErrorHistoryDBFileNotFound(historyDBPath)
+		}
+		return nil, textmsg.ErrorUnableStatHistoryDB(historyDBPath, err)
+	}
+	db, err := sql.Open("sqlite3", historyDBSQLiteURI(historyDBPath))
 	if err != nil {
 		return nil, err
 	}
 	return db, nil
+}
+
+func historyDBSQLiteURI(historyDBPath string) string {
+	if filepath.IsAbs(historyDBPath) {
+		dbURI := url.URL{Scheme: "file", Path: historyDBPath, RawQuery: "mode=rw"}
+		return dbURI.String()
+	}
+	return fmt.Sprintf("file:%s?mode=rw", historyDBPath)
 }
 
 // GetBackupDataDB Read backup data from history database and return BackupConfig struct.

--- a/gpbckpconfig/utils_db_test.go
+++ b/gpbckpconfig/utils_db_test.go
@@ -1,6 +1,95 @@
 package gpbckpconfig
 
-import "testing"
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/woblerr/gpbackman/textmsg"
+)
+
+func TestOpenHistoryDBMissingFile(t *testing.T) {
+	missingPath := filepath.Join(t.TempDir(), "missing_history.db")
+	db, err := OpenHistoryDB(missingPath)
+	if err == nil {
+		t.Fatalf("Expected OpenHistoryDB to fail for a missing file")
+	}
+	if db != nil {
+		t.Fatalf("Expected nil database handle for a missing file")
+	}
+	if want := textmsg.ErrorHistoryDBFileNotFound(missingPath).Error(); err.Error() != want {
+		t.Errorf("Unexpected error:\n%v\nwant:\n%v", err, want)
+	}
+	if _, statErr := os.Stat(missingPath); !os.IsNotExist(statErr) {
+		t.Fatalf("Expected missing history DB to stay absent, stat error: %v", statErr)
+	}
+}
+
+func TestOpenHistoryDBExistingFile(t *testing.T) {
+	historyDBPath := filepath.Join(t.TempDir(), "gpbackup_history.db")
+	seedDB, err := sql.Open("sqlite3", "file:"+historyDBPath+"?mode=rwc")
+	if err != nil {
+		t.Fatalf("Failed to create seed SQLite DB: %v", err)
+	}
+	if err = seedDB.Ping(); err != nil {
+		t.Fatalf("Failed to ping seed SQLite DB: %v", err)
+	}
+	if err = seedDB.Close(); err != nil {
+		t.Fatalf("Failed to close seed SQLite DB: %v", err)
+	}
+
+	db, err := OpenHistoryDB(historyDBPath)
+	if err != nil {
+		t.Fatalf("Expected OpenHistoryDB to open existing DB, got: %v", err)
+	}
+	if db == nil {
+		t.Fatalf("Expected non-nil database handle")
+	}
+	if err = db.Ping(); err != nil {
+		t.Fatalf("Failed to ping opened SQLite DB: %v", err)
+	}
+	if err = db.Close(); err != nil {
+		t.Fatalf("Failed to close opened SQLite DB: %v", err)
+	}
+}
+
+func TestOpenHistoryDBExistingRelativeFile(t *testing.T) {
+	oldWorkingDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Failed to read current directory: %v", err)
+	}
+	if err = os.Chdir(t.TempDir()); err != nil {
+		t.Fatalf("Failed to switch to temp directory: %v", err)
+	}
+	defer func() {
+		if chdirErr := os.Chdir(oldWorkingDir); chdirErr != nil {
+			t.Fatalf("Failed to restore current directory: %v", chdirErr)
+		}
+	}()
+
+	seedDB, err := sql.Open("sqlite3", "file:gpbackup_history.db?mode=rwc")
+	if err != nil {
+		t.Fatalf("Failed to create seed SQLite DB: %v", err)
+	}
+	if err = seedDB.Ping(); err != nil {
+		t.Fatalf("Failed to ping seed SQLite DB: %v", err)
+	}
+	if err = seedDB.Close(); err != nil {
+		t.Fatalf("Failed to close seed SQLite DB: %v", err)
+	}
+
+	db, err := OpenHistoryDB("gpbackup_history.db")
+	if err != nil {
+		t.Fatalf("Expected OpenHistoryDB to open relative DB path, got: %v", err)
+	}
+	if err = db.Ping(); err != nil {
+		t.Fatalf("Failed to ping opened SQLite DB: %v", err)
+	}
+	if err = db.Close(); err != nil {
+		t.Fatalf("Failed to close opened SQLite DB: %v", err)
+	}
+}
 
 func TestGetBackupNameQuery(t *testing.T) {
 	tests := []struct {

--- a/textmsg/error.go
+++ b/textmsg/error.go
@@ -27,11 +27,11 @@ func ErrorTextUnableInitHistoryDB(err error) string {
 }
 
 func ErrorHistoryDBFileNotFound(path string) error {
-	return fmt.Errorf("History db file not found: %s", path)
+	return fmt.Errorf("history db file not found: %s", path)
 }
 
 func ErrorUnableStatHistoryDB(path string, err error) error {
-	return fmt.Errorf("Unable to stat history db %s. Error: %v", path, err)
+	return fmt.Errorf("unable to stat history db %s, error: %v", path, err)
 }
 
 // Errors that occur when working with a history db.

--- a/textmsg/error.go
+++ b/textmsg/error.go
@@ -26,6 +26,14 @@ func ErrorTextUnableInitHistoryDB(err error) string {
 	return fmt.Sprintf("Unable to initialize history db. Error: %v", err)
 }
 
+func ErrorHistoryDBFileNotFound(path string) error {
+	return fmt.Errorf("History db file not found: %s", path)
+}
+
+func ErrorUnableStatHistoryDB(path string, err error) error {
+	return fmt.Errorf("Unable to stat history db %s. Error: %v", path, err)
+}
+
 // Errors that occur when working with a history db.
 
 func ErrorTextUnableActionHistoryFile(value string, err error) string {

--- a/textmsg/error_test.go
+++ b/textmsg/error_test.go
@@ -316,6 +316,12 @@ func TestErrorFunctionsOneoArg(t *testing.T) {
 			errFunc: ErrorSeveralFoundBackupDirIn,
 			want:    "several backup directory found in TestValue",
 		},
+		{
+			name:    "ErrorHistoryDBFileNotFound",
+			value:   "TestValue",
+			errFunc: ErrorHistoryDBFileNotFound,
+			want:    "History db file not found: TestValue",
+		},
 	}
 	for _, tt := range tests {
 		err := tt.errFunc(tt.value)
@@ -340,6 +346,13 @@ func TestErrorFunctionsOneoArgAndErr(t *testing.T) {
 			err:     testErr,
 			errFunc: ErrorFindBackupDirIn,
 			want:    "can not find backup directory in TestValue, error: test error",
+		},
+		{
+			name:    "ErrorUnableStatHistoryDB",
+			value:   "TestValue",
+			err:     testErr,
+			errFunc: ErrorUnableStatHistoryDB,
+			want:    "Unable to stat history db TestValue. Error: test error",
 		},
 	}
 	for _, tt := range tests {

--- a/textmsg/error_test.go
+++ b/textmsg/error_test.go
@@ -320,7 +320,7 @@ func TestErrorFunctionsOneoArg(t *testing.T) {
 			name:    "ErrorHistoryDBFileNotFound",
 			value:   "TestValue",
 			errFunc: ErrorHistoryDBFileNotFound,
-			want:    "History db file not found: TestValue",
+			want:    "history db file not found: TestValue",
 		},
 	}
 	for _, tt := range tests {
@@ -352,7 +352,7 @@ func TestErrorFunctionsOneoArgAndErr(t *testing.T) {
 			value:   "TestValue",
 			err:     testErr,
 			errFunc: ErrorUnableStatHistoryDB,
-			want:    "Unable to stat history db TestValue. Error: test error",
+			want:    "unable to stat history db TestValue, error: test error",
 		},
 	}
 	for _, tt := range tests {

--- a/third_party_licenses/APACHE-2.0.txt
+++ b/third_party_licenses/APACHE-2.0.txt
@@ -1,0 +1,160 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and
+distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright
+owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities
+that control, are controlled by, or are under common control with that entity.
+For the purposes of this definition, "control" means (i) the power, direct or
+indirect, to cause the direction or management of such entity, whether by
+contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the
+outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising
+permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including
+but not limited to software source code, documentation source, and configuration
+files.
+
+"Object" form shall mean any form resulting from mechanical transformation or
+translation of a Source form, including but not limited to compiled object code,
+generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form,
+made available under the License, as indicated by a copyright notice that is
+included in or attached to the work (an example is provided in the Appendix
+below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that
+is based on (or derived from) the Work and for which the editorial revisions,
+annotations, elaborations, or other modifications represent, as a whole, an
+original work of authorship. For the purposes of this License, Derivative Works
+shall not include works that remain separable from, or merely link (or bind by
+name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version
+of the Work and any modifications or additions to that Work or Derivative Works
+thereof, that is intentionally submitted to Licensor for inclusion in the Work
+by the copyright owner or by an individual or Legal Entity authorized to submit
+on behalf of the copyright owner. For the purposes of this definition,
+"submitted" means any form of electronic, verbal, or written communication sent
+to the Licensor or its representatives, including but not limited to
+communication on electronic mailing lists, source code control systems, and
+issue tracking systems that are managed by, or on behalf of, the Licensor for
+the purpose of discussing and improving the Work, but excluding communication
+that is conspicuously marked or otherwise designated in writing by the copyright
+owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf
+of whom a Contribution has been received by Licensor and subsequently
+incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this
+License, each Contributor hereby grants to You a perpetual, worldwide,
+non-exclusive, no-charge, royalty-free, irrevocable copyright license to
+reproduce, prepare Derivative Works of, publicly display, publicly perform,
+sublicense, and distribute the Work and such Derivative Works in Source or
+Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this License,
+each Contributor hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section) patent
+license to make, have made, use, offer to sell, sell, import, and otherwise
+transfer the Work, where such license applies only to those patent claims
+licensable by such Contributor that are necessarily infringed by their
+Contribution(s) alone or by combination of their Contribution(s) with the Work
+to which such Contribution(s) was submitted. If You institute patent litigation
+against any entity (including a cross-claim or counterclaim in a lawsuit)
+alleging that the Work or a Contribution incorporated within the Work
+constitutes direct or contributory patent infringement, then any patent licenses
+granted to You under this License for that Work shall terminate as of the date
+such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or
+Derivative Works thereof in any medium, with or without modifications, and in
+Source or Object form, provided that You meet the following conditions:
+
+(a) You must give any other recipients of the Work or Derivative Works a copy of
+    this License; and
+
+(b) You must cause any modified files to carry prominent notices stating that
+    You changed the files; and
+
+(c) You must retain, in the Source form of any Derivative Works that You
+    distribute, all copyright, patent, trademark, and attribution notices from
+    the Source form of the Work, excluding those notices that do not pertain to
+    any part of the Derivative Works; and
+
+(d) If the Work includes a "NOTICE" text file as part of its distribution, then
+    any Derivative Works that You distribute must include a readable copy of the
+    attribution notices contained within such NOTICE file, excluding those
+    notices that do not pertain to any part of the Derivative Works, in at least
+    one of the following places: within a NOTICE text file distributed as part of
+    the Derivative Works; within the Source form or documentation, if provided
+    along with the Derivative Works; or, within a display generated by the
+    Derivative Works, if and wherever such third-party notices normally appear.
+    The contents of the NOTICE file are for informational purposes only and do
+    not modify the License. You may add Your own attribution notices within
+    Derivative Works that You distribute, alongside or as an addendum to the
+    NOTICE text from the Work, provided that such additional attribution notices
+    cannot be construed as modifying the License.
+
+You may add Your own copyright statement to Your modifications and may provide
+additional or different license terms and conditions for use, reproduction, or
+distribution of Your modifications, or for any such Derivative Works as a whole,
+provided Your use, reproduction, and distribution of the Work otherwise complies
+with the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise, any
+Contribution intentionally submitted for inclusion in the Work by You to the
+Licensor shall be under the terms and conditions of this License, without any
+additional terms or conditions. Notwithstanding the above, nothing herein shall
+supersede or modify the terms of any separate license agreement you may have
+executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade names,
+trademarks, service marks, or product names of the Licensor, except as required
+for reasonable and customary use in describing the origin of the Work and
+reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in
+writing, Licensor provides the Work (and each Contributor provides its
+Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied, including, without limitation, any warranties or
+conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+PARTICULAR PURPOSE. You are solely responsible for determining the
+appropriateness of using or redistributing the Work and assume any risks
+associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether in
+tort (including negligence), contract, or otherwise, unless required by
+applicable law (such as deliberate and grossly negligent acts) or agreed to in
+writing, shall any Contributor be liable to You for damages, including any
+direct, indirect, special, incidental, or consequential damages of any character
+arising as a result of this License or out of the use or inability to use the
+Work (including but not limited to damages for loss of goodwill, work stoppage,
+computer failure or malfunction, or any and all other commercial damages or
+losses), even if such Contributor has been advised of the possibility of such
+damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work or
+Derivative Works thereof, You may choose to offer, and charge a fee for,
+acceptance of support, warranty, indemnity, or other liability obligations
+and/or rights consistent with this License. However, in accepting such
+obligations, You may act only on Your own behalf and on Your sole
+responsibility, not on behalf of any other Contributor, and only if You agree to
+indemnify, defend, and hold each Contributor harmless for any liability incurred
+by, or claims asserted against, such Contributor by reason of your accepting any
+such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS


### PR DESCRIPTION
Backport and adapt Apache Cloudberry Backup history db auto-load behavior.

- Add `--auto-load-history-db` to resolve `gpbackup_history.db` from `MASTER_DATA_DIRECTORY` or `COORDINATOR_DATA_DIRECTORY` when `--history-db` is not set.
- Open existing history db files in read-write mode and fail before SQLite can create a missing db for read-only commands.
- Reject `--history-db` together with `--auto-load-history-db`.
- Add unit and e2e coverage for auto-load behavior.
- Add third-party notices and Apache License text for the backported changes.