### PR TITLE
Add history-sync commnad.

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,7 +77,10 @@ make test-e2e_backup-delete
 make test-e2e_backup-clean
 make test-e2e_history-clean
 make test-e2e_history-migrate
+make test-e2e_history-sync
 ```
+
+The `backup-delete`, `backup-clean`, `history-clean`, and `history-sync` suites use the standby-aware fixture.
 
 Stop and remove e2e containers and volumes with:
 
@@ -119,13 +122,15 @@ Do not remove no-op or regression e2e cases without an explicit decision.
   create a new `gpbackup_history.db`, or rename `gpbackup_history.yaml` to `.migrated`.
   Manual tests must use temp or copied data unless the user explicitly points to real data.
 - Preserve standby sync semantics.
-  It runs only after successful `backup-delete`, `backup-clean`, or `history-clean` operations,
-  only when the resolved history database path is the cluster history database at
+  Explicit `history-sync` treats an ineligible source, no up standby, and discovery or transfer failures
+  as errors and exits non-zero.
+  Automatic sync runs only after successful `backup-delete`, `backup-clean`, or `history-clean` operations
+  and remains best-effort.
+  Both modes require the resolved history database path to be the cluster history database at
   `<primary coordinator data directory>/gpbackup_history.db`.
-  Custom history databases and the default working-directory `gpbackup_history.db` path are skipped.
-  The sync is also skipped when `--no-history-sync-standby` is specified, when no up standby coordinator
-  is found, or when the source history database is not the cluster history database.
-  Sync failures warn and must not mask the primary command success.
+  For automatic sync, custom and default working-directory databases are skipped,
+  `--no-history-sync-standby` disables the attempt, and no up standby is also a skip.
+  Automatic sync failures warn and must not mask the primary command success.
 - Standby sync copies only `gpbackup_history.db`.
   It does not sync reports, backup data, or other backup artifacts.
 - Keep `README.md`, `COMMANDS.md`, `e2e_tests/README.md`, and relevant e2e scripts synchronized

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -658,33 +658,23 @@ docker run \
 
 # Synchronize the cluster history database to the standby coordinator (`history-sync`)
 
-`history-sync` explicitly synchronizes the cluster `gpbackup_history.db` to an up standby coordinator.
-It accepts no positional arguments and has no command-specific flags.
-It inherits the root `--history-db` and `--auto-load-history-db` source flags, which cannot be used together.
-It does not accept `--no-history-sync-standby`; that flag controls only automatic post-mutation sync.
+Available options for `history-sync` command and their description:
 
-The source must resolve to `<primary coordinator data directory>/gpbackup_history.db`.
-Use `--history-db` for that explicit path, or use `--auto-load-history-db` to resolve it from `MASTER_DATA_DIRECTORY` first, then `COORDINATOR_DATA_DIRECTORY`.
-If neither source flag is provided, the default working-directory `gpbackup_history.db` is not eligible.
-For cluster discovery, `history-sync` connects to the local cluster using `PGDATABASE`, or `postgres` when `PGDATABASE` is unset.
-The connection also honors `PGUSER`, `PGHOST`, and `PGPORT`.
+```bash
+./gpbackman history-sync -h
+Synchronize the cluster gpbackup_history.db to an up standby coordinator.
 
-Synchronization requires the local `ssh` and `rsync` executables.
-The SSH connection uses the invoking OS account, independently of `PGUSER`.
-That account must exist on the standby, have non-interactive SSH access, and be allowed to create a temporary file and replace `gpbackup_history.db` in the standby coordinator data directory.
-The project Docker images include these executables.
-The deb and rpm packages declare them as dependencies.
-
-Successful completion means the history database was synchronized.
-No up standby coordinator, an ineligible or unresolved source, and any discovery, snapshot, validation, SSH, or rsync failure are errors that exit non-zero.
+The source history database must be the cluster history database.
+Use --history-db to select an explicit source file, or --auto-load-history-db to resolve it from the coordinator data directory.
+The command fails when no standby coordinator is available or when the source database is not eligible for synchronization.
 
 Usage:
-```bash
-gpbackman history-sync [flags]
-```
+  gpbackman history-sync [flags]
+
+Flags:
+  -h, --help   help for history-sync
 
 Global Flags:
-```text
       --auto-load-history-db       resolve gpbackup_history.db from $MASTER_DATA_DIRECTORY or $COORDINATOR_DATA_DIRECTORY when --history-db is unset
       --history-db string          full path to the gpbackup_history.db file
       --log-file string            full path to log file directory, if not specified, the log file will be created in the $HOME/gpAdminLogs directory

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -22,19 +22,21 @@
 - [Migrate history database (`history-migrate`)](#migrate-history-database-history-migrate)
   - [Examples](#examples-4)
   - [Using container](#using-container-4)
-- [Display the report for a specific backup (`report-info`)](#display-the-report-for-a-specific-backup-report-info)
+- [Synchronize the cluster history database to the standby coordinator (`history-sync`)](#synchronize-the-cluster-history-database-to-the-standby-coordinator-history-sync)
   - [Examples](#examples-5)
+- [Display the report for a specific backup (`report-info`)](#display-the-report-for-a-specific-backup-report-info)
+  - [Examples](#examples-6)
     - [Display the backup report from local storage](#display-the-backup-report-from-local-storage)
     - [Display the backup report using storage plugin](#display-the-backup-report-using-storage-plugin)
   - [Using container](#using-container-5)
 
 # Standby history DB sync
 
-After a successful `backup-delete`, `backup-clean`, or `history-clean`, gpBackMan syncs the cluster `gpbackup_history.db` to an up standby coordinator when sync conditions are met. Sync failures are logged as warnings and do not mask the primary command success.
+The explicit `history-sync` command synchronizes the cluster `gpbackup_history.db` to an up standby coordinator. It does not have successful skips: an unavailable standby, an ineligible source, or a discovery, snapshot, validation, SSH, or rsync error is reported as an error and returns a non-zero exit status.
 
-The sync only runs when the resolved history database path is the cluster history database at `<primary coordinator data directory>/gpbackup_history.db`. This path can be selected with `--history-db` or with `--auto-load-history-db` when the environment points to the coordinator data directory. Custom history databases and the default working-directory `gpbackup_history.db` path are skipped.
+The source must resolve to the cluster history database at `<primary coordinator data directory>/gpbackup_history.db`. It can be selected with `--history-db` or with `--auto-load-history-db` when the environment points to the coordinator data directory. Custom history databases and the default working-directory `gpbackup_history.db` path are not eligible for explicit synchronization.
 
-The sync is skipped when `--no-history-sync-standby` is specified for `backup-delete`, `backup-clean`, or `history-clean`, when no up standby coordinator is found, or when the source history database is not the cluster history database. Read-only commands such as `backup-info` and `report-info` do not trigger sync.
+After successful `backup-delete`, `backup-clean`, or `history-clean`, gpBackMan also attempts this sync automatically. This automatic sync is best-effort: `--no-history-sync-standby` produces an info-level skip, while no up standby and ineligible sources are debug-only skips; discovery, snapshot, validation, SSH, and rsync failures are warnings and do not mask the successful primary command. Read-only commands such as `backup-info` and `report-info` do not trigger automatic sync.
 
 Only `gpbackup_history.db` is synced. Report files, backup data, and other backup artifacts are not synced by gpBackMan.
 
@@ -652,6 +654,55 @@ docker run \
   gpbackman history-migrate \
   --history-file /data/master/gpseg-1/gpbackup_history.yaml \
   --history-db /data/master/gpseg-1/gpbackup_history.db
+```
+
+# Synchronize the cluster history database to the standby coordinator (`history-sync`)
+
+`history-sync` explicitly synchronizes the cluster `gpbackup_history.db` to an up standby coordinator.
+It accepts no positional arguments and has no command-specific flags.
+It inherits the root `--history-db` and `--auto-load-history-db` source flags, which cannot be used together.
+It does not accept `--no-history-sync-standby`; that flag controls only automatic post-mutation sync.
+
+The source must resolve to `<primary coordinator data directory>/gpbackup_history.db`.
+Use `--history-db` for that explicit path, or use `--auto-load-history-db` to resolve it from `MASTER_DATA_DIRECTORY` first, then `COORDINATOR_DATA_DIRECTORY`.
+If neither source flag is provided, the default working-directory `gpbackup_history.db` is not eligible.
+For cluster discovery, `history-sync` connects to the local cluster using `PGDATABASE`, or `postgres` when `PGDATABASE` is unset.
+The connection also honors `PGUSER`, `PGHOST`, and `PGPORT`.
+
+Synchronization requires the local `ssh` and `rsync` executables.
+The SSH connection uses the invoking OS account, independently of `PGUSER`.
+That account must exist on the standby, have non-interactive SSH access, and be allowed to create a temporary file and replace `gpbackup_history.db` in the standby coordinator data directory.
+The project Docker images include these executables.
+The deb and rpm packages declare them as dependencies.
+
+Successful completion means the history database was synchronized.
+No up standby coordinator, an ineligible or unresolved source, and any discovery, snapshot, validation, SSH, or rsync failure are errors that exit non-zero.
+
+Usage:
+```bash
+gpbackman history-sync [flags]
+```
+
+Global Flags:
+```text
+      --auto-load-history-db       resolve gpbackup_history.db from $MASTER_DATA_DIRECTORY or $COORDINATOR_DATA_DIRECTORY when --history-db is unset
+      --history-db string          full path to the gpbackup_history.db file
+      --log-file string            full path to log file directory, if not specified, the log file will be created in the $HOME/gpAdminLogs directory
+      --log-level-console string   level for console logging (error, info, debug, verbose) (default "info")
+      --log-level-file string      level for file logging (error, info, debug, verbose) (default "info")
+```
+
+## Examples
+
+Synchronize an explicitly selected cluster history database:
+```bash
+./gpbackman history-sync \
+  --history-db /data/master/gpseg-1/gpbackup_history.db
+```
+
+Resolve the cluster history database from the coordinator environment and synchronize it:
+```bash
+./gpbackman history-sync --auto-load-history-db
 ```
 
 # Display the report for a specific backup (`report-info`)

--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,9 @@ GPDB_CONTAINER_NAME := greenplum
 GPDB_USER := gpadmin
 E2E_DEFAULT_COMPOSE_FILE := e2e_tests/docker-compose.yml
 E2E_STANDBY_COMPOSE_FILE := e2e_tests/docker-compose.standby.yml
-E2E_STANDBY_COMMANDS := backup-delete backup-clean history-clean
+E2E_STANDBY_COMMANDS := backup-delete backup-clean history-clean history-sync
 # List of all e2e test commands
-E2E_COMMANDS := backup-info report-info backup-delete backup-clean history-clean history-migrate
+E2E_COMMANDS := backup-info report-info backup-delete backup-clean history-clean history-migrate history-sync
 
 .PHONY: test
 test:

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ The utility provides functionality for migrating data from the old `gpbackup_his
 * delete all existing backups from local storage or using storage plugins older than the specified time condition;
 * clean deleted backups from the history database;
 * migrate history database from `gpbackup_history.yaml` format to `gpbackup_history.db` SQLite format;
-* sync the cluster `gpbackup_history.db` to the standby coordinator after successful backup deletion and history cleanup.
+* manually sync the cluster `gpbackup_history.db` to the standby coordinator;
+* automatically sync the cluster `gpbackup_history.db` after successful backup deletion and history cleanup.
 
 ## Commands
 ### Introduction
@@ -39,6 +40,7 @@ Available Commands:
   help            Help about any command
   history-clean   Clean deleted backups from the history database
   history-migrate Migrate history database
+  history-sync    Synchronize the cluster history database to the standby coordinator
   report-info     Display the report for a specific backup
 
 Flags:
@@ -55,9 +57,15 @@ Use "gpbackman [command] --help" for more information about a command.
 
 ### Standby history DB sync
 
-After a successful `backup-delete`, `backup-clean`, or `history-clean`, gpBackMan syncs the cluster `gpbackup_history.db` to an up standby coordinator when sync conditions are met. Sync failures are logged as warnings and do not change the primary command result.
+Run `history-sync` to explicitly synchronize the cluster `gpbackup_history.db` to an up standby coordinator. The source must resolve to `<primary coordinator data directory>/gpbackup_history.db`; a custom database or the default working-directory database is not eligible. Explicit sync treats every non-sync outcome as an error and exits non-zero, including no up standby coordinator, an ineligible source, discovery errors, and transfer errors.
 
-Sync runs only when the resolved history database path is the cluster history database at `<primary coordinator data directory>/gpbackup_history.db`. Custom history databases and the default working-directory `gpbackup_history.db` path are skipped. The sync is also skipped when no up standby coordinator is found, or when `--no-history-sync-standby` is specified for `backup-delete`, `backup-clean`, or `history-clean`.
+For the usual cluster setup, prefer resolving the source from the coordinator data directory:
+
+```bash
+./gpbackman history-sync --auto-load-history-db
+```
+
+After a successful `backup-delete`, `backup-clean`, or `history-clean`, gpBackMan also attempts the same synchronization automatically. Automatic sync is best-effort: ineligible source paths and no standby are debug-only skips, while sync failures are warnings and do not change the successful primary command result. Pass `--no-history-sync-standby` to those mutation commands to disable their automatic sync.
 
 Only `gpbackup_history.db` is synced. Report files, backup data, and any other backup artifacts are not synced by gpBackMan.
 
@@ -69,6 +77,7 @@ Description of each command:
 * [Display information about backups (`backup-info`)](./COMMANDS.md#display-information-about-backups-backup-info)
 * [Clean deleted backups from the history database (`history-clean`)](./COMMANDS.md#clean-deleted-backups-from-the-history-database-history-clean)
 * [Migrate history database (`history-migrate`)](./COMMANDS.md#migrate-history-database-history-migrate)
+* [Synchronize the cluster history database to the standby coordinator (`history-sync`)](./COMMANDS.md#synchronize-the-cluster-history-database-to-the-standby-coordinator-history-sync)
 * [Display the report for a specific backup (`report-info`)](./COMMANDS.md#display-the-report-for-a-specific-backup-report-info)
 
 ## Getting Started

--- a/cmd/history_standby_sync.go
+++ b/cmd/history_standby_sync.go
@@ -43,8 +43,13 @@ func syncHistoryStandbyBestEffort(clusterDBName string, noHistorySyncStandby boo
 		gplog.Info("%s", textmsg.InfoTextHistoryStandbySyncSkipped("disabled by --"+noHistorySyncStandbyFlagName))
 		return
 	}
-	if err := syncHistoryStandby(clusterDBName); err != nil {
+	skipReason, err := syncHistoryStandby(clusterDBName)
+	if err != nil {
 		gplog.Warn("%s", textmsg.WarnTextHistoryStandbySyncFailed(err))
+		return
+	}
+	if skipReason != "" {
+		gplog.Debug("%s", textmsg.InfoTextHistoryStandbySyncSkipped(skipReason))
 	}
 }
 
@@ -57,31 +62,29 @@ func runHistoryMutationWithStandbySync(work func() (string, error), noHistorySyn
 	syncHistoryStandbyBestEffort(clusterDBName, noHistorySyncStandby)
 }
 
-func syncHistoryStandby(clusterDBName string) error {
+func syncHistoryStandby(clusterDBName string) (string, error) {
 	sourceDBPath, shouldDiscover, skipReason := getHistoryStandbySyncSourceDBPath()
 	if !shouldDiscover {
-		gplog.Debug("%s", textmsg.InfoTextHistoryStandbySyncSkipped(skipReason))
-		return nil
+		return skipReason, nil
 	}
 
 	target, skipReason, err := discoverHistoryStandbySyncTarget(sourceDBPath, clusterDBName)
 	if err != nil {
-		return err
+		return "", err
 	}
 	if skipReason != "" {
-		gplog.Debug("%s", textmsg.InfoTextHistoryStandbySyncSkipped(skipReason))
-		return nil
+		return skipReason, nil
 	}
 	gplog.Info("%s", textmsg.InfoTextHistoryStandbySyncStart(target.sourceDBPath))
 
 	if err := withHistoryStandbySyncSnapshot(target.sourceDBPath, func(snapshotPath string) error {
 		return syncHistoryStandbySnapshotToStandby(target, snapshotPath)
 	}); err != nil {
-		return err
+		return "", err
 	}
 
 	gplog.Info("%s", textmsg.InfoTextHistoryStandbySyncSuccess(target.standbyHost, target.standbyHistoryDBPath))
-	return nil
+	return "", nil
 }
 
 // Standby sync is allowed only for the cluster history db.

--- a/cmd/history_standby_sync_test.go
+++ b/cmd/history_standby_sync_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/greenplum-db/gpbackup/history"
 	"github.com/jmoiron/sqlx"
 	"github.com/woblerr/gpbackman/gpbckpconfig"
+	"github.com/woblerr/gpbackman/textmsg"
 )
 
 func TestSyncHistoryStandbyOrchestratesDiscoverySnapshotTransferAndInstall(t *testing.T) {
@@ -29,8 +30,8 @@ func TestSyncHistoryStandbyOrchestratesDiscoverySnapshotTransferAndInstall(t *te
 		tmpDir = rawTmpDir
 	}
 	primaryDataDir := filepath.Join(tmpDir, "primary")
-	if err := os.Mkdir(primaryDataDir, 0o700); err != nil {
-		t.Fatalf("Failed to create primary data dir: %v", err)
+	if mkdirErr := os.Mkdir(primaryDataDir, 0o700); mkdirErr != nil {
+		t.Fatalf("Failed to create primary data dir: %v", mkdirErr)
 	}
 	sourceDBPath := filepath.Join(primaryDataDir, historyDBNameConst)
 	createHistoryStandbySyncTempSQLiteDB(t, sourceDBPath)
@@ -55,8 +56,12 @@ func TestSyncHistoryStandbyOrchestratesDiscoverySnapshotTransferAndInstall(t *te
 		{exitCode: 0},
 	})
 
-	if err := syncHistoryStandby("testdb"); err != nil {
+	skipReason, err := syncHistoryStandby("testdb")
+	if err != nil {
 		t.Fatalf("Expected sync orchestration to succeed, got: %v", err)
+	}
+	if skipReason != "" {
+		t.Fatalf("Expected successful sync not to return a skip reason, got: %s", skipReason)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("Unmet SQL expectations: %v", err)
@@ -92,8 +97,12 @@ func TestSyncHistoryStandbySkipsWhenDiscoveryFindsNoTarget(t *testing.T) {
 	})
 	setHistoryStandbySyncExecCommand(t, nil)
 
-	if err := syncHistoryStandby(""); err != nil {
-		t.Fatalf("Expected skipped sync to succeed, got: %v", err)
+	skipReason, err := syncHistoryStandby("")
+	if err != nil {
+		t.Fatalf("Expected skipped sync not to return an error, got: %v", err)
+	}
+	if skipReason != "no up standby coordinator found" {
+		t.Fatalf("Unexpected skip reason: %s", skipReason)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("Unmet SQL expectations: %v", err)
@@ -117,7 +126,7 @@ func TestSyncHistoryStandbyReturnsSnapshotError(t *testing.T) {
 	})
 	setHistoryStandbySyncExecCommand(t, nil)
 
-	err := syncHistoryStandby("")
+	_, err := syncHistoryStandby("")
 	if err == nil {
 		t.Fatalf("Expected sync orchestration to fail")
 	}
@@ -152,7 +161,7 @@ func TestSyncHistoryStandbyReturnsTransferError(t *testing.T) {
 		{exitCode: 0},
 	})
 
-	err := syncHistoryStandby("")
+	_, err := syncHistoryStandby("")
 	if err == nil {
 		t.Fatalf("Expected sync orchestration to fail")
 	}
@@ -165,7 +174,7 @@ func TestSyncHistoryStandbyReturnsTransferError(t *testing.T) {
 }
 
 func TestSyncHistoryStandbyBestEffortSkipsWhenDisabled(t *testing.T) {
-	testhelper.SetupTestLogger()
+	testStdout, _, _ := testhelper.SetupTestLogger()
 
 	setHistoryStandbySyncRootFlags(t, "/primary/gpbackup_history.db", false)
 	clusterConnCalls := 0
@@ -178,10 +187,14 @@ func TestSyncHistoryStandbyBestEffortSkipsWhenDisabled(t *testing.T) {
 	if clusterConnCalls != 0 {
 		t.Fatalf("\nCluster connection call count does not match:\n%v\nwant:\n%v", clusterConnCalls, 0)
 	}
+	wantLog := textmsg.InfoTextHistoryStandbySyncSkipped("disabled by --" + noHistorySyncStandbyFlagName)
+	if logOutput := string(testStdout.Contents()); !strings.Contains(logOutput, wantLog) {
+		t.Fatalf("Expected disabled sync log %q, got: %s", wantLog, logOutput)
+	}
 }
 
 func TestSyncHistoryStandbyBestEffortWarnsAndDoesNotExit(t *testing.T) {
-	testhelper.SetupTestLogger()
+	testStdout, _, _ := testhelper.SetupTestLogger()
 
 	setHistoryStandbySyncRootFlags(t, "/primary/gpbackup_history.db", false)
 	setHistoryStandbySyncNewClusterConnHook(t, func(clusterDBName string) (*sqlx.DB, error) {
@@ -195,6 +208,35 @@ func TestSyncHistoryStandbyBestEffortWarnsAndDoesNotExit(t *testing.T) {
 	syncHistoryStandbyBestEffort("", false)
 	if exitCalled {
 		t.Fatalf("Expected standby sync failure not to exit the process")
+	}
+	wantLog := textmsg.WarnTextHistoryStandbySyncFailed(
+		errors.New("connect to local cluster for standby history sync discovery: discovery failed"),
+	)
+	if logOutput := string(testStdout.Contents()); !strings.Contains(logOutput, wantLog) {
+		t.Fatalf("Expected standby sync warning %q, got: %s", wantLog, logOutput)
+	}
+}
+
+func TestSyncHistoryStandbyBestEffortLogsSkipReasonAndDoesNotExit(t *testing.T) {
+	_, _, testLogfile := testhelper.SetupTestLogger()
+
+	setHistoryStandbySyncRootFlags(t, "", false)
+	setHistoryStandbySyncNewClusterConnHook(t, func(clusterDBName string) (*sqlx.DB, error) {
+		t.Fatal("History sync discovery should not run for the default source")
+		return nil, nil
+	})
+	exitCalled := false
+	setHistoryStandbySyncExecOSExit(t, func(code int) {
+		exitCalled = true
+	})
+
+	syncHistoryStandbyBestEffort("", false)
+	if exitCalled {
+		t.Fatalf("Expected skipped standby sync not to exit the process")
+	}
+	wantLog := textmsg.InfoTextHistoryStandbySyncSkipped("using default working-directory history db")
+	if logOutput := string(testLogfile.Contents()); !strings.Contains(logOutput, wantLog) {
+		t.Fatalf("Expected standby sync debug skip log %q, got: %s", wantLog, logOutput)
 	}
 }
 
@@ -244,8 +286,12 @@ func TestSyncHistoryStandbySkipsDefaultSourceSelectionBeforeDiscovery(t *testing
 				return nil, errors.New("cluster connection should not run")
 			})
 
-			if err := syncHistoryStandby(""); err != nil {
-				t.Fatalf("Expected skipped sync to succeed, got: %v", err)
+			skipReason, err := syncHistoryStandby("")
+			if err != nil {
+				t.Fatalf("Expected skipped sync not to return an error, got: %v", err)
+			}
+			if skipReason == "" {
+				t.Fatalf("Expected skipped sync to return a reason")
 			}
 			if clusterConnCalls != 0 {
 				t.Fatalf("\nCluster connection call count does not match:\n%v\nwant:\n%v", clusterConnCalls, 0)
@@ -295,8 +341,12 @@ func TestSyncHistoryStandbySkipsIneligibleExplicitSourceBeforeDiscovery(t *testi
 				return nil, errors.New("cluster connection should not run")
 			})
 
-			if err := syncHistoryStandby(""); err != nil {
-				t.Fatalf("Expected skipped sync to succeed, got: %v", err)
+			skipReason, err := syncHistoryStandby("")
+			if err != nil {
+				t.Fatalf("Expected skipped sync not to return an error, got: %v", err)
+			}
+			if skipReason == "" {
+				t.Fatalf("Expected skipped sync to return a reason")
 			}
 			if clusterConnCalls != 0 {
 				t.Fatalf("\nCluster connection call count does not match:\n%v\nwant:\n%v", clusterConnCalls, 0)

--- a/cmd/history_sync.go
+++ b/cmd/history_sync.go
@@ -1,0 +1,45 @@
+package cmd
+
+import (
+	"errors"
+
+	"github.com/greenplum-db/gp-common-go-libs/gplog"
+	"github.com/spf13/cobra"
+	"github.com/woblerr/gpbackman/textmsg"
+)
+
+var syncHistoryStandbyForCommand = syncHistoryStandby
+
+var historySyncCmd = &cobra.Command{
+	Use:   "history-sync",
+	Short: "Synchronize the cluster history database to the standby coordinator",
+	Long: `Synchronize the cluster gpbackup_history.db to an up standby coordinator.
+
+The source history database must be the cluster history database.
+Use --history-db to select an explicit source file, or --auto-load-history-db to resolve it from the coordinator data directory.
+The command fails when no standby coordinator is available or when the source database is not eligible for synchronization.`,
+	Args: cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		doRootFlagValidation(cmd.Flags(), checkFileExistsConst)
+		doHistorySync()
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(historySyncCmd)
+}
+
+func doHistorySync() {
+	logHeadersDebug()
+	skipReason, err := syncHistoryStandbyForCommand("")
+	if err != nil {
+		gplog.Error("%s", textmsg.ErrorTextUnableActionHistoryDB("synchronize", err))
+		execOSExit(exitErrorCode)
+		return
+	}
+	if skipReason != "" {
+		gplog.Error("%s", textmsg.ErrorTextUnableActionHistoryDB("synchronize", errors.New(skipReason)))
+		execOSExit(exitErrorCode)
+		return
+	}
+}

--- a/cmd/history_sync_test.go
+++ b/cmd/history_sync_test.go
@@ -1,0 +1,256 @@
+package cmd
+
+import (
+	"bytes"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/greenplum-db/gp-common-go-libs/testhelper"
+)
+
+func TestHistorySyncCommandRegistration(t *testing.T) {
+	command, _, err := rootCmd.Find([]string{"history-sync"})
+	if err != nil {
+		t.Fatalf("Expected history-sync command to be registered, got: %v", err)
+	}
+	if command != historySyncCmd {
+		t.Fatalf("Unexpected command registered for history-sync: %p", command)
+	}
+	if historySyncCmd.Use != "history-sync" {
+		t.Fatalf("Unexpected command use: %s", historySyncCmd.Use)
+	}
+	if err := historySyncCmd.Args(historySyncCmd, []string{"unexpected"}); err == nil {
+		t.Fatal("Expected history-sync to reject positional arguments")
+	}
+	for _, flagName := range []string{historyDBFlagName, autoLoadHistoryDBFlagName} {
+		if flag := historySyncCmd.InheritedFlags().Lookup(flagName); flag == nil {
+			t.Fatalf("Expected history-sync to inherit --%s", flagName)
+		}
+	}
+}
+
+func TestHistorySyncCommandSucceedsAndPassesEmptyClusterDBName(t *testing.T) {
+	testhelper.SetupTestLogger()
+
+	syncCalls := 0
+	setHistorySyncStandbyHook(t, func(clusterDBName string) (string, error) {
+		syncCalls++
+		if clusterDBName != "" {
+			t.Fatalf("Unexpected cluster database name: %q", clusterDBName)
+		}
+		return "", nil
+	})
+	exitCalls := 0
+	setHistoryStandbySyncExecOSExit(t, func(code int) {
+		exitCalls++
+	})
+
+	executeHistorySyncCommand(t)
+
+	if exitCalls != 0 {
+		t.Fatalf("history-sync unexpectedly exited %d times", exitCalls)
+	}
+	if syncCalls != 1 {
+		t.Fatalf("Expected one history sync call, got: %d", syncCalls)
+	}
+}
+
+func TestHistorySyncCommandFailsForSyncErrorsAndSkipReasons(t *testing.T) {
+	tests := []struct {
+		name       string
+		skipReason string
+		syncErr    error
+		wantCause  string
+	}{
+		{
+			name:      "Sync Error",
+			syncErr:   errors.New("discovery failed"),
+			wantCause: "discovery failed",
+		},
+		{
+			name:       "No Up Standby",
+			skipReason: "no up standby coordinator found",
+			wantCause:  "no up standby coordinator found",
+		},
+		{
+			name:       "Ineligible Source",
+			skipReason: "custom history db is not cluster history db",
+			wantCause:  "is not cluster history db",
+		},
+		{
+			name:       "Default Working Directory Source",
+			skipReason: "using default working-directory history db",
+			wantCause:  "using default working-directory history db",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, testStderr, _ := testhelper.SetupTestLogger()
+			syncCalls := 0
+			setHistorySyncStandbyHook(t, func(clusterDBName string) (string, error) {
+				syncCalls++
+				if clusterDBName != "" {
+					t.Fatalf("Unexpected cluster database name: %q", clusterDBName)
+				}
+				return tt.skipReason, tt.syncErr
+			})
+			exitCalls := 0
+			setHistoryStandbySyncExecOSExit(t, func(code int) {
+				if code != exitErrorCode {
+					t.Fatalf("Unexpected exit code: %d", code)
+				}
+				exitCalls++
+			})
+
+			executeHistorySyncCommand(t)
+
+			if exitCalls != 1 {
+				t.Fatalf("Expected one error exit, got: %d", exitCalls)
+			}
+			if syncCalls != 1 {
+				t.Fatalf("Expected one history sync call, got: %d", syncCalls)
+			}
+			logOutput := string(testStderr.Contents())
+			if !strings.Contains(logOutput, "Unable to synchronize history db. Error:") {
+				t.Fatalf("Expected history-sync error message, got: %s", logOutput)
+			}
+			if !strings.Contains(logOutput, tt.wantCause) {
+				t.Fatalf("Expected history-sync error to contain %q, got: %s", tt.wantCause, logOutput)
+			}
+		})
+	}
+}
+
+func TestHistorySyncCommandRootValidationRejectsMissingOrIncompatibleSourceFlags(t *testing.T) {
+	testhelper.SetupTestLogger()
+
+	tests := []struct {
+		name string
+		args func(*testing.T) []string
+	}{
+		{
+			name: "Missing Explicit Source",
+			args: func(t *testing.T) []string {
+				return []string{"--" + historyDBFlagName, filepath.Join(t.TempDir(), historyDBNameConst)}
+			},
+		},
+		{
+			name: "Incompatible Source Flags",
+			args: func(t *testing.T) []string {
+				path := filepath.Join(t.TempDir(), historyDBNameConst)
+				createHistoryStandbySyncTempSQLiteDB(t, path)
+				return []string{"--" + historyDBFlagName, path, "--" + autoLoadHistoryDBFlagName}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setHistorySyncStandbyHook(t, func(string) (string, error) {
+				t.Fatal("History sync should not run when root validation fails")
+				return "", nil
+			})
+			type exitPanic struct{ code int }
+			setHistoryStandbySyncExecOSExit(t, func(code int) {
+				panic(exitPanic{code: code})
+			})
+
+			defer func() {
+				value := recover()
+				if value == nil {
+					t.Fatal("Expected root validation to exit")
+				}
+				exit, ok := value.(exitPanic)
+				if !ok {
+					panic(value)
+				}
+				if exit.code != exitErrorCode {
+					t.Fatalf("Unexpected exit code: %d", exit.code)
+				}
+			}()
+
+			executeHistorySyncCommand(t, tt.args(t)...)
+		})
+	}
+}
+
+func executeHistorySyncCommand(t *testing.T, args ...string) {
+	t.Helper()
+
+	resetHistorySyncSourceFlags(t)
+	rootCmd.SetArgs(append([]string{"history-sync"}, args...))
+	t.Cleanup(func() {
+		rootCmd.SetArgs(nil)
+	})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Expected history-sync command execution to return no error, got: %v", err)
+	}
+}
+
+func resetHistorySyncSourceFlags(t *testing.T) {
+	t.Helper()
+
+	flags := rootCmd.PersistentFlags()
+	historyDBFlag := flags.Lookup(historyDBFlagName)
+	autoLoadHistoryDBFlag := flags.Lookup(autoLoadHistoryDBFlagName)
+	oldRootHistoryDB := rootHistoryDB
+	oldRootAutoLoadHistoryDB := rootAutoLoadHistoryDB
+	oldHistoryDBChanged := historyDBFlag.Changed
+	oldAutoLoadHistoryDBChanged := autoLoadHistoryDBFlag.Changed
+
+	rootHistoryDB = ""
+	rootAutoLoadHistoryDB = false
+	historyDBFlag.Changed = false
+	autoLoadHistoryDBFlag.Changed = false
+
+	t.Cleanup(func() {
+		rootHistoryDB = oldRootHistoryDB
+		rootAutoLoadHistoryDB = oldRootAutoLoadHistoryDB
+		historyDBFlag.Changed = oldHistoryDBChanged
+		autoLoadHistoryDBFlag.Changed = oldAutoLoadHistoryDBChanged
+	})
+}
+
+func setHistorySyncStandbyHook(t *testing.T, hook func(string) (string, error)) {
+	t.Helper()
+
+	oldHook := syncHistoryStandbyForCommand
+	syncHistoryStandbyForCommand = hook
+	t.Cleanup(func() {
+		syncHistoryStandbyForCommand = oldHook
+	})
+}
+
+func TestHistorySyncCommandHasNoLocalNoHistorySyncStandbyFlag(t *testing.T) {
+	if flag := historySyncCmd.PersistentFlags().Lookup(noHistorySyncStandbyFlagName); flag != nil {
+		t.Fatalf("Expected history-sync not to define --%s", noHistorySyncStandbyFlagName)
+	}
+	if flag := historySyncCmd.LocalFlags().Lookup(noHistorySyncStandbyFlagName); flag != nil {
+		t.Fatalf("Expected history-sync not to define a local --%s", noHistorySyncStandbyFlagName)
+	}
+}
+
+func TestHistorySyncCommandHelpContainsSourceFlagsWithoutNoHistorySyncStandby(t *testing.T) {
+	var output bytes.Buffer
+	historySyncCmd.SetOut(&output)
+	t.Cleanup(func() {
+		historySyncCmd.SetOut(nil)
+	})
+
+	if err := historySyncCmd.Help(); err != nil {
+		t.Fatalf("Expected history-sync help to succeed, got: %v", err)
+	}
+
+	help := output.String()
+	for _, flagName := range []string{historyDBFlagName, autoLoadHistoryDBFlagName} {
+		if !strings.Contains(help, "--"+flagName) {
+			t.Fatalf("Expected history-sync help to include --%s", flagName)
+		}
+	}
+	if strings.Contains(help, "--"+noHistorySyncStandbyFlagName) {
+		t.Fatalf("Expected history-sync help not to include --%s", noHistorySyncStandbyFlagName)
+	}
+}

--- a/cmd/wrappers_test.go
+++ b/cmd/wrappers_test.go
@@ -100,13 +100,14 @@ func TestRootAutoLoadHistoryDBFlag(t *testing.T) {
 	flag := rootCmd.PersistentFlags().Lookup(autoLoadHistoryDBFlagName)
 	if flag == nil {
 		t.Fatalf("Expected %s flag to be registered", autoLoadHistoryDBFlagName)
-	}
-	if flag.DefValue != "false" {
-		t.Errorf("\nDefault value does not match:\n%v\nwant:\n%v", flag.DefValue, "false")
-	}
-	if !strings.Contains(flag.Usage, "MASTER_DATA_DIRECTORY") ||
-		!strings.Contains(flag.Usage, "COORDINATOR_DATA_DIRECTORY") {
-		t.Errorf("Flag usage does not mention both data directory environment variables: %s", flag.Usage)
+	} else {
+		if flag.DefValue != "false" {
+			t.Errorf("\nDefault value does not match:\n%v\nwant:\n%v", flag.DefValue, "false")
+		}
+		if !strings.Contains(flag.Usage, "MASTER_DATA_DIRECTORY") ||
+			!strings.Contains(flag.Usage, "COORDINATOR_DATA_DIRECTORY") {
+			t.Errorf("Flag usage does not mention both data directory environment variables: %s", flag.Usage)
+		}
 	}
 }
 
@@ -146,12 +147,13 @@ func TestNoHistorySyncStandbyFlagRegisteredOnSyncCommands(t *testing.T) {
 			flag := tt.flags.Lookup(noHistorySyncStandbyFlagName)
 			if flag == nil {
 				t.Fatalf("Expected %s flag to be registered", noHistorySyncStandbyFlagName)
-			}
-			if flag.DefValue != "false" {
-				t.Errorf("\nDefault value does not match:\n%v\nwant:\n%v", flag.DefValue, "false")
-			}
-			if !strings.Contains(flag.Usage, "standby coordinator") {
-				t.Errorf("Flag usage does not mention standby coordinator: %s", flag.Usage)
+			} else {
+				if flag.DefValue != "false" {
+					t.Errorf("\nDefault value does not match:\n%v\nwant:\n%v", flag.DefValue, "false")
+				}
+				if !strings.Contains(flag.Usage, "standby coordinator") {
+					t.Errorf("Flag usage does not mention standby coordinator: %s", flag.Usage)
+				}
 			}
 		})
 	}

--- a/e2e_tests/README.md
+++ b/e2e_tests/README.md
@@ -5,7 +5,7 @@ The e2e suite uses two Docker Compose fixtures.
 - `docker-compose.yml` runs the default single-node Greenplum fixture.
   It is used by `backup-info`, `report-info`, and `history-migrate`.
 - `docker-compose.standby.yml` runs a standby-aware Greenplum fixture.
-  It is used by `backup-delete`, `backup-clean`, and `history-clean`.
+  It is used by `backup-delete`, `backup-clean`, `history-clean`, and `history-sync`.
 
 Both fixtures include [minio/minio](https://hub.docker.com/r/minio/minio) and [minio/mc](https://hub.docker.com/r/minio/mc) containers for S3-compatible backup storage.
 The `gpbackman-export` container copies the built `gpbackman` binary to the shared `gpbackman_bin` volume.
@@ -44,9 +44,10 @@ make test-e2e_backup-delete
 make test-e2e_backup-clean
 make test-e2e_history-clean
 make test-e2e_history-migrate
+make test-e2e_history-sync
 ```
 
-`backup-delete`, `backup-clean`, and `history-clean` each start a fresh standby-aware cluster, prepare backups, run the full suite for that command, and remove disposable volumes.
+`backup-delete`, `backup-clean`, `history-clean`, and `history-sync` each start a fresh standby-aware cluster, prepare backups, run the full suite for that command, and remove disposable volumes.
 
 Manually run a single-node command suite:
 
@@ -64,6 +65,8 @@ docker exec greenplum bash -c 'su - gpadmin -c "/home/gpadmin/run_tests/run_test
 docker compose -f e2e_tests/docker-compose.standby.yml down -v
 ```
 
+For the explicit history-sync scenario, replace `backup-delete` with `history-sync` in the command above.
+
 If a manual run fails, recreate the fixture before retrying:
 
 ```bash
@@ -73,7 +76,7 @@ docker compose -f e2e_tests/docker-compose.yml down -v --remove-orphans
 
 ## Standby-aware checks
 
-The `backup-delete`, `backup-clean`, and `history-clean` suites run against the cluster history database at `/data/master/gpseg-1/gpbackup_history.db`.
+The `backup-delete`, `backup-clean`, `history-clean`, and `history-sync` suites run against the cluster history database at `/data/master/gpseg-1/gpbackup_history.db`.
 That path is eligible for standby history sync.
 
 The mutating suites assert:
@@ -82,6 +85,9 @@ The mutating suites assert:
 - primary and standby history produce matching `gpbackman backup-info` output after successful sync;
 - `--no-history-sync-standby` applies the primary mutation and leaves the selected standby state unchanged;
 - a fake `rsync` failure keeps the primary command successful and emits the standby sync warning.
+
+The `history-sync` suite first seeds the standby with an explicit sync, then disables automatic sync for a primary `backup-delete` so the histories differ.
+It runs `history-sync --auto-load-history-db`, verifies the explicit sync success message, and confirms the primary and standby rows match again.
 
 ## Notes
 

--- a/e2e_tests/scripts/run_tests/run_history-sync.sh
+++ b/e2e_tests/scripts/run_tests/run_history-sync.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/common_functions.sh"
+
+COMMAND="history-sync"
+
+# Seed the standby through an explicit sync, mutate primary history without its
+# automatic sync, then synchronize the now-stale standby through auto-load.
+test_history_sync_after_disabled_backup_delete() {
+    local timestamp
+    local output
+    local primary_row
+    local standby_row
+
+    output=$(run_gpbackman_capture "${COMMAND}" "seed_standby_explicit" --history-db "${HISTORY_DB}")
+    assert_history_sync_success_output "${output}"
+
+    timestamp="$(get_active_local_backup_timestamp "full")"
+    output=$(run_gpbackman_capture "backup-delete" "delete_without_standby_sync" --history-db "${HISTORY_DB}" --timestamp "${timestamp}" --no-history-sync-standby)
+    assert_history_sync_disabled_output "${output}"
+    assert_primary_backup_deleted "${timestamp}"
+
+    primary_row="$(primary_backup_row_for_timestamp "${timestamp}")"
+    standby_row="$(standby_backup_row_for_timestamp "${timestamp}")"
+    if [ -z "${primary_row}" ] || [ -z "${standby_row}" ]; then
+        echo "[ERROR] Expected primary and standby history rows for ${timestamp}"
+        exit 1
+    fi
+    if [ "${primary_row}" = "${standby_row}" ]; then
+        echo "[ERROR] Standby history row should remain stale after disabled automatic sync"
+        exit 1
+    fi
+
+    output=$(run_gpbackman_capture "${COMMAND}" "sync_stale_standby_auto_load" --auto-load-history-db)
+    assert_history_sync_success_output "${output}"
+    assert_primary_standby_backup_row_match "${timestamp}"
+}
+
+run_test "${COMMAND}" 1 test_history_sync_after_disabled_backup_delete
+
+log_all_tests_passed "${COMMAND}"

--- a/e2e_tests/scripts/run_tests/run_history-sync.sh
+++ b/e2e_tests/scripts/run_tests/run_history-sync.sh
@@ -32,7 +32,11 @@ test_history_sync_after_disabled_backup_delete() {
         exit 1
     fi
 
-    output=$(run_gpbackman_capture "${COMMAND}" "sync_stale_standby_auto_load" --auto-load-history-db)
+    output=$(
+        export MASTER_DATA_DIRECTORY="${DATA_DIR}"
+        unset COORDINATOR_DATA_DIRECTORY
+        run_gpbackman_capture "${COMMAND}" "sync_stale_standby_auto_load" --auto-load-history-db
+    )
     assert_history_sync_success_output "${output}"
     assert_primary_standby_backup_row_match "${timestamp}"
 }

--- a/e2e_tests/scripts/run_tests/run_test.sh
+++ b/e2e_tests/scripts/run_tests/run_test.sh
@@ -8,7 +8,7 @@ SCRIPTS_DIR="${HOME_DIR}/run_tests"
 
 command_requires_standby() {
     case "${TEST_COMMAND}" in
-        backup-delete|backup-clean|history-clean)
+        backup-delete|backup-clean|history-clean|history-sync)
             return 0
             ;;
         *)
@@ -69,6 +69,9 @@ exec_test_for_command() {
             ;;
         history-migrate)
             "${SCRIPTS_DIR}/run_history-migrate.sh"
+            ;;
+        history-sync)
+            "${SCRIPTS_DIR}/run_history-sync.sh"
             ;;
         *)
             echo "[ERROR] Unknown test command: ${TEST_COMMAND}"


### PR DESCRIPTION
Add `history-sync` commnad - manually synchronize the cluster history database to the standby coordinator.
Update e2e tests and docs for `history-sync` command.